### PR TITLE
リファクタリング

### DIFF
--- a/Analysis/KaisekiNyuumonn/KaisekiNyuumonn1.v
+++ b/Analysis/KaisekiNyuumonn/KaisekiNyuumonn1.v
@@ -7666,7 +7666,7 @@ move=> H1.
 rewrite H1.
 rewrite - (Vopp_mul_distr_r (RnVS N) 1 y).
 rewrite (Vopp_mul_distr_l (RnVS N) 1 y).
-have: ((Rnmult N (- 1) y) = (Vmul (RnVS N) (Fopp (F (RnVS N)) 1) y)).
+have: ((Rnmult N (- 1) y) = (Vmul (RnVS N) (Fopp (VF (RnVS N)) 1) y)).
 simpl.
 reflexivity.
 move=> H2.
@@ -8223,7 +8223,7 @@ elim (classic ((RnInnerProduct N x x) = 0)).
 move=> H2.
 exists 0.
 left.
-suff: ((Rnmult N 0 y) = (Vmul (RnVS N) (FO (F (RnVS N))) y)).
+suff: ((Rnmult N 0 y) = (Vmul (RnVS N) (FO (VF (RnVS N))) y)).
 move=> H3.
 rewrite H3.
 rewrite (Vmul_O_l (RnVS N) y).
@@ -8684,7 +8684,7 @@ unfold Rn_dist.
 rewrite H1.
 rewrite - (Vopp_minus_distr (RnVS N) x y).
 rewrite - (Vmul_I_l (RnVS N) (Vadd (RnVS N) x (Vopp (RnVS N) y))).
-rewrite (Vopp_mul_distr_l (RnVS N) (FI (F (RnVS N))) (Vadd (RnVS N) x (Vopp (RnVS N) y))).
+rewrite (Vopp_mul_distr_l (RnVS N) (FI (VF (RnVS N))) (Vadd (RnVS N) x (Vopp (RnVS N) y))).
 simpl.
 rewrite (Proposition_4_4_1 N (- 1) (Rnplus N x (Rnopp N y))).
 rewrite (Rabs_Ropp 1).
@@ -23418,12 +23418,12 @@ move=> H14.
 rewrite H14.
 reflexivity.
 rewrite - {1} (Vmul_I_l (RnVS N) (Vopp (RnVS N) r)).
-rewrite - (Vopp_mul_distr_r (RnVS N) (FI (F (RnVS N))) r).
-rewrite (Vopp_mul_distr_l (RnVS N) (FI (F (RnVS N))) r).
-rewrite - (Vmul_add_distr_r (RnVS N) (1 - t) (Fopp (F (RnVS N)) (FI (F (RnVS N)))) r).
+rewrite - (Vopp_mul_distr_r (RnVS N) (FI (VF (RnVS N))) r).
+rewrite (Vopp_mul_distr_l (RnVS N) (FI (VF (RnVS N))) r).
+rewrite - (Vmul_add_distr_r (RnVS N) (1 - t) (Fopp (VF (RnVS N)) (FI (VF (RnVS N)))) r).
 rewrite - (Vopp_mul_distr_r (RnVS N) t r).
 rewrite (Vopp_mul_distr_l (RnVS N) t r).
-suff: ((Fadd (F (RnVS N)) (1 - t) (Fopp (F (RnVS N)) (FI (F (RnVS N))))) = (Fopp (F (RnVS N)) t)).
+suff: ((Fadd (VF (RnVS N)) (1 - t) (Fopp (VF (RnVS N)) (FI (VF (RnVS N))))) = (Fopp (VF (RnVS N)) t)).
 move=> H14.
 rewrite H14.
 reflexivity.
@@ -23850,13 +23850,13 @@ rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) (y - b) r03) (Vadd (RnVS N) (Vopp (Rn
 rewrite (Vadd_assoc (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02)) (Vopp (RnVS N) (Vmul (RnVS N) (r - b) r03)) (Vmul (RnVS N) (y - b) r03)).
 rewrite - (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - (y - b)) r02) (Vopp (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02)) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (r - b) r03)) (Vmul (RnVS N) (y - b) r03))).
 rewrite (Vopp_mul_distr_l (RnVS N) (1 - (r - b)) r02).
-rewrite - (Vmul_add_distr_r (RnVS N) (1 - (y - b)) (Fopp (F (RnVS N)) (1 - (r - b))) r02).
-suff: ((Fadd (F (RnVS N)) (1 - (y - b)) (Fopp (F (RnVS N)) (1 - (r - b)))) = r - y).
+rewrite - (Vmul_add_distr_r (RnVS N) (1 - (y - b)) (Fopp (VF (RnVS N)) (1 - (r - b))) r02).
+suff: ((Fadd (VF (RnVS N)) (1 - (y - b)) (Fopp (VF (RnVS N)) (1 - (r - b)))) = r - y).
 move=> H14.
 rewrite H14.
 rewrite (Vopp_mul_distr_l (RnVS N) (r - b) r03).
-rewrite - (Vmul_add_distr_r (RnVS N) (Fopp (F (RnVS N)) (r - b)) (y - b) r03).
-suff: ((Fadd (F (RnVS N)) (Fopp (F (RnVS N)) (r - b)) (y - b)) = - (r - y)).
+rewrite - (Vmul_add_distr_r (RnVS N) (Fopp (VF (RnVS N)) (r - b)) (y - b) r03).
+suff: ((Fadd (VF (RnVS N)) (Fopp (VF (RnVS N)) (r - b)) (y - b)) = - (r - y)).
 move=> H15.
 rewrite H15.
 rewrite - (Vopp_mul_distr_l (RnVS N) (r - y) r03).
@@ -24304,13 +24304,13 @@ rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) z y) (Vadd (RnVS N) (Vopp (RnVS N) (V
 rewrite (Vadd_assoc (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - r) x)) (Vopp (RnVS N) (Vmul (RnVS N) r y)) (Vmul (RnVS N) z y)).
 rewrite - (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - z) x) (Vopp (RnVS N) (Vmul (RnVS N) (1 - r) x)) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) r y)) (Vmul (RnVS N) z y))).
 rewrite (Vopp_mul_distr_l (RnVS N) (1 - r) x).
-rewrite - (Vmul_add_distr_r (RnVS N) (1 - z) (Fopp (F (RnVS N)) (1 - r)) x).
-suff: ((Fadd (F (RnVS N)) (1 - z) (Fopp (F (RnVS N)) (1 - r))) = r - z).
+rewrite - (Vmul_add_distr_r (RnVS N) (1 - z) (Fopp (VF (RnVS N)) (1 - r)) x).
+suff: ((Fadd (VF (RnVS N)) (1 - z) (Fopp (VF (RnVS N)) (1 - r))) = r - z).
 move=> H10.
 rewrite H10.
 rewrite (Vopp_mul_distr_l (RnVS N) r y).
-rewrite - (Vmul_add_distr_r (RnVS N) (Fopp (F (RnVS N)) r) z y).
-suff: ((Fadd (F (RnVS N)) (Fopp (F (RnVS N)) r) z) = - (r - z)).
+rewrite - (Vmul_add_distr_r (RnVS N) (Fopp (VF (RnVS N)) r) z y).
+suff: ((Fadd (VF (RnVS N)) (Fopp (VF (RnVS N)) r) z) = - (r - z)).
 move=> H11.
 rewrite H11.
 rewrite - (Vopp_mul_distr_l (RnVS N) (r - z) y).

--- a/MyAlgebraicStructure/MyVectorSpace.v
+++ b/MyAlgebraicStructure/MyVectorSpace.v
@@ -10,20 +10,20 @@ Section VectorSpace.
 
 Record VectorSpace : Type := mkVectorSpace
 {
-F   : Field;
+VF   : Field;
 VT   : Type;
 VO : VT;
 Vadd : VT -> VT -> VT;
-Vmul : (FT F) -> VT -> VT;
+Vmul : (FT VF) -> VT -> VT;
 Vopp : VT -> VT;
 Vadd_comm : forall (x y : VT), (Vadd x y) = (Vadd y x);
 Vadd_assoc : forall (x y z : VT), (Vadd (Vadd x y) z) = (Vadd x (Vadd y z));
 Vadd_O_l : forall x : VT, (Vadd VO x) = x;
 Vadd_opp_r : forall x : VT, (Vadd x (Vopp x)) = VO;
-Vmul_add_distr_l : forall (x : FT F) (y z : VT), (Vmul x (Vadd y z)) = (Vadd (Vmul x y) (Vmul x z));
-Vmul_add_distr_r : forall (x y : FT F) (z : VT), (Vmul (Fadd F x y) z) = (Vadd (Vmul x z) (Vmul y z));
-Vmul_assoc : forall (x y : FT F) (z : VT), (Vmul x (Vmul y z)) = (Vmul (Fmul F x y) z);
-Vmul_I_l : forall x : VT, (Vmul (FI F) x) = x;
+Vmul_add_distr_l : forall (x : FT VF) (y z : VT), (Vmul x (Vadd y z)) = (Vadd (Vmul x y) (Vmul x z));
+Vmul_add_distr_r : forall (x y : FT VF) (z : VT), (Vmul (Fadd VF x y) z) = (Vadd (Vmul x z) (Vmul y z));
+Vmul_assoc : forall (x y : FT VF) (z : VT), (Vmul x (Vmul y z)) = (Vmul (Fmul VF x y) z);
+Vmul_I_l : forall x : VT, (Vmul (FI VF) x) = x;
 }.
 
 Lemma Vadd_O_r : forall (v : VectorSpace) (x : VT v), (Vadd v x (VO v)) = x.
@@ -111,7 +111,7 @@ rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_O_r : forall (v : VectorSpace) (x : FT (F v)), (Vmul v x (VO v)) = (VO v).
+Lemma Vmul_O_r : forall (v : VectorSpace) (x : FT (VF v)), (Vmul v x (VO v)) = (VO v).
 Proof.
 move=> v x.
 apply (Vadd_O_r_uniq v (Vmul v x (VO v)) (Vmul v x (VO v))).
@@ -120,72 +120,72 @@ rewrite (Vadd_O_l v (VO v)).
 by [].
 Qed.
 
-Lemma Vmul_O_l : forall (v : VectorSpace) (x : VT v), (Vmul v (FO (F v)) x) = (VO v).
+Lemma Vmul_O_l : forall (v : VectorSpace) (x : VT v), (Vmul v (FO (VF v)) x) = (VO v).
 Proof.
 move=> v x.
-apply (Vadd_O_r_uniq v (Vmul v (FO (F v)) x) (Vmul v (FO (F v)) x)).
-rewrite - (Vmul_add_distr_r v (FO (F v)) (FO (F v)) x).
-rewrite (Fadd_O_l (F v) (FO (F v))).
+apply (Vadd_O_r_uniq v (Vmul v (FO (VF v)) x) (Vmul v (FO (VF v)) x)).
+rewrite - (Vmul_add_distr_r v (FO (VF v)) (FO (VF v)) x).
+rewrite (Fadd_O_l (VF v) (FO (VF v))).
 by [].
 Qed.
 
-Lemma Vmul_eq_compat_l : forall (v : VectorSpace) (x : FT (F v)) (y z : VT v), y = z -> (Vmul v x y) = (Vmul v x z).
+Lemma Vmul_eq_compat_l : forall (v : VectorSpace) (x : FT (VF v)) (y z : VT v), y = z -> (Vmul v x y) = (Vmul v x z).
 Proof.
 move=> v x y z H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_eq_compat_r : forall (v : VectorSpace) (x : VT v) (y z : FT (F v)), y = z -> (Vmul v y x) = (Vmul v z x).
+Lemma Vmul_eq_compat_r : forall (v : VectorSpace) (x : VT v) (y z : FT (VF v)), y = z -> (Vmul v y x) = (Vmul v z x).
 Proof.
 move=> v x y z H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_eq_reg_l : forall (v : VectorSpace) (x : FT (F v)) (y z : VT v), (Vmul v x y) = (Vmul v x z) -> x <> (FO (F v)) -> y = z.
+Lemma Vmul_eq_reg_l : forall (v : VectorSpace) (x : FT (VF v)) (y z : VT v), (Vmul v x y) = (Vmul v x z) -> x <> (FO (VF v)) -> y = z.
 Proof.
 move=> v x y z H1 H2.
 rewrite - (Vmul_I_l v y).
 rewrite - (Vmul_I_l v z).
-rewrite - (Finv_l (F v) x H2).
-rewrite - (Vmul_assoc v (Finv (F v) x) x y).
-rewrite - (Vmul_assoc v (Finv (F v) x) x z).
+rewrite - (Finv_l (VF v) x H2).
+rewrite - (Vmul_assoc v (Finv (VF v) x) x y).
+rewrite - (Vmul_assoc v (Finv (VF v) x) x z).
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_eq_reg_r : forall (v : VectorSpace) (x : VT v) (y z : FT (F v)), (Vmul v y x) = (Vmul v z x) -> x <> (VO v) -> y = z.
+Lemma Vmul_eq_reg_r : forall (v : VectorSpace) (x : VT v) (y z : FT (VF v)), (Vmul v y x) = (Vmul v z x) -> x <> (VO v) -> y = z.
 Proof.
 move=> v x y z H1 H2.
 apply NNPP.
 move=> H3.
 apply H2.
 rewrite - (Vmul_I_l v x).
-rewrite - (Finv_l (F v) (Fadd (F v) y (Fopp (F v) z))).
-rewrite - (Vmul_assoc v (Finv (F v) (Fadd (F v) y (Fopp (F v) z))) (Fadd (F v) y (Fopp (F v) z)) x).
-suff: ((Vmul v (Fadd (F v) y (Fopp (F v) z)) x) = VO v).
+rewrite - (Finv_l (VF v) (Fadd (VF v) y (Fopp (VF v) z))).
+rewrite - (Vmul_assoc v (Finv (VF v) (Fadd (VF v) y (Fopp (VF v) z))) (Fadd (VF v) y (Fopp (VF v) z)) x).
+suff: ((Vmul v (Fadd (VF v) y (Fopp (VF v) z)) x) = VO v).
 move=> H4.
 rewrite H4.
-apply (Vmul_O_r v (Finv (F v) (Fadd (F v) y (Fopp (F v) z)))).
-apply (Vadd_eq_reg_r v (Vmul v z x) (Vmul v (Fadd (F v) y (Fopp (F v) z)) x) (VO v)).
+apply (Vmul_O_r v (Finv (VF v) (Fadd (VF v) y (Fopp (VF v) z)))).
+apply (Vadd_eq_reg_r v (Vmul v z x) (Vmul v (Fadd (VF v) y (Fopp (VF v) z)) x) (VO v)).
 rewrite (Vadd_O_l v (Vmul v z x)).
-rewrite (Vmul_add_distr_r v y (Fopp (F v) z) x).
-rewrite (Vadd_assoc v (Vmul v y x) (Vmul v (Fopp (F v) z) x) (Vmul v z x)).
-rewrite - (Vmul_add_distr_r v (Fopp (F v) z) z x).
-rewrite (Fadd_opp_l (F v) z).
+rewrite (Vmul_add_distr_r v y (Fopp (VF v) z) x).
+rewrite (Vadd_assoc v (Vmul v y x) (Vmul v (Fopp (VF v) z) x) (Vmul v z x)).
+rewrite - (Vmul_add_distr_r v (Fopp (VF v) z) z x).
+rewrite (Fadd_opp_l (VF v) z).
 rewrite (Vmul_O_l v x).
 rewrite H1.
 apply (Vadd_O_r v (Vmul v z x)).
 move=> H4.
 apply H3.
-apply (Fminus_diag_uniq (F v) y z H4).
+apply (Fminus_diag_uniq (VF v) y z H4).
 Qed.
 
-Lemma Vmul_integral : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vmul v x y) = (VO v) -> x = (FO (F v)) \/ y = (VO v).
+Lemma Vmul_integral : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v x y) = (VO v) -> x = (FO (VF v)) \/ y = (VO v).
 Proof.
 move=> v x y H1.
-apply (NNPP (x = FO (F v) \/ y = VO v)).
+apply (NNPP (x = FO (VF v) \/ y = VO v)).
 move=> H2.
 apply H2.
 right.
@@ -199,7 +199,7 @@ left.
 apply H3.
 Qed.
 
-Lemma Vmul_eq_O_compat : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (x = (FO (F v)) \/ y = (VO v)) -> (Vmul v x y) = (VO v).
+Lemma Vmul_eq_O_compat : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (x = (FO (VF v)) \/ y = (VO v)) -> (Vmul v x y) = (VO v).
 Proof.
 move=> v x y H1.
 case H1.
@@ -211,21 +211,21 @@ rewrite H2.
 apply (Vmul_O_r v x).
 Qed.
 
-Lemma Vmul_eq_O_compat_r : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), x = (FO (F v)) -> (Vmul v x y) = (VO v).
+Lemma Vmul_eq_O_compat_r : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), x = (FO (VF v)) -> (Vmul v x y) = (VO v).
 Proof.
 move=> v x y H1.
 rewrite H1.
 apply (Vmul_O_l v y).
 Qed.
 
-Lemma Vmul_eq_O_compat_l : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), y = (VO v) -> (Vmul v x y) = (VO v).
+Lemma Vmul_eq_O_compat_l : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), y = (VO v) -> (Vmul v x y) = (VO v).
 Proof.
 move=> v x y H1.
 rewrite H1.
 apply (Vmul_O_r v x).
 Qed.
 
-Lemma Vmul_neq_O_reg : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vmul v x y) <> (VO v) -> x <> (FO (F v)) /\ y <> (VO v).
+Lemma Vmul_neq_O_reg : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v x y) <> (VO v) -> x <> (FO (VF v)) /\ y <> (VO v).
 Proof.
 move=> v x y H1.
 apply conj.
@@ -239,23 +239,21 @@ rewrite H2.
 apply (Vmul_O_r v x).
 Qed.
 
-Lemma Vmul_integral_contrapositive : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), x <> (FO (F v)) /\ y <> (VO v) -> (Vmul v x y) <> (VO v).
+Lemma Vmul_integral_contrapositive : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), x <> (FO (VF v)) /\ y <> (VO v) -> (Vmul v x y) <> (VO v).
 Proof.
-move=> v x y H1.
-move=> H2.
+move=> v x y H1 H2.
 apply (proj1 H1).
-apply (Vmul_eq_reg_r v y x (FO (F v))).
+apply (Vmul_eq_reg_r v y x (FO (VF v))).
 rewrite (Vmul_O_l v y).
 apply H2.
 apply (proj2 H1).
 Qed.
 
-Lemma Vmul_integral_contrapositive_currified : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), x <> (FO (F v)) -> y <> (VO v) -> (Vmul v x y) <> (VO v).
+Lemma Vmul_integral_contrapositive_currified : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), x <> (FO (VF v)) -> y <> (VO v) -> (Vmul v x y) <> (VO v).
 Proof.
-move=> v x y H1 H2.
-move=> H3.
+move=> v x y H1 H2 H3.
 apply H1.
-apply (Vmul_eq_reg_r v y x (FO (F v))).
+apply (Vmul_eq_reg_r v y x (FO (VF v))).
 rewrite (Vmul_O_l v y).
 apply H3.
 apply H2.
@@ -318,27 +316,27 @@ rewrite (Vadd_O_r v y).
 apply (Vadd_opp_r v y).
 Qed.
 
-Lemma Vopp_mul_distr_l : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vopp v (Vmul v x y)) = (Vmul v (Fopp (F v) x) y).
+Lemma Vopp_mul_distr_l : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vopp v (Vmul v x y)) = (Vmul v (Fopp (VF v) x) y).
 Proof.
 move=> v x y.
-suff: Vmul v (Fopp (F v) x) y = Vopp v (Vmul v x y).
+suff: Vmul v (Fopp (VF v) x) y = Vopp v (Vmul v x y).
 move=> H1.
 rewrite H1.
 by [].
 apply (Vadd_opp_r_uniq v (Vmul v x y)).
-rewrite - (Vmul_add_distr_r v x (Fopp (F v) x) y).
-rewrite (Fadd_opp_r (F v) x).
+rewrite - (Vmul_add_distr_r v x (Fopp (VF v) x) y).
+rewrite (Fadd_opp_r (VF v) x).
 apply (Vmul_O_l v y).
 Qed.
 
-Lemma Vopp_mul_distr_l_reverse : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vmul v (Fopp (F v) x) y) = (Vopp v (Vmul v x y)).
+Lemma Vopp_mul_distr_l_reverse : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v (Fopp (VF v) x) y) = (Vopp v (Vmul v x y)).
 Proof.
 move=> v x y.
 rewrite (Vopp_mul_distr_l v x y).
 reflexivity.
 Qed.
 
-Lemma Vopp_mul_distr_r : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vopp v (Vmul v x y)) = (Vmul v x (Vopp v y)).
+Lemma Vopp_mul_distr_r : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vopp v (Vmul v x y)) = (Vmul v x (Vopp v y)).
 Proof.
 move=> v x y.
 suff: Vmul v x (Vopp v y) = Vopp v (Vmul v x y).
@@ -351,14 +349,14 @@ rewrite (Vadd_opp_r v y).
 apply (Vmul_O_r v x).
 Qed.
 
-Lemma Vopp_mul_distr_r_reverse : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vmul v x (Vopp v y)) = (Vopp v (Vmul v x y)).
+Lemma Vopp_mul_distr_r_reverse : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v x (Vopp v y)) = (Vopp v (Vmul v x y)).
 Proof.
 move=> v x y.
 rewrite (Vopp_mul_distr_r v x y).
 reflexivity.
 Qed.
 
-Lemma Vmul_opp_opp : forall (v : VectorSpace) (x : FT (F v)) (y : VT v), (Vmul v (Fopp (F v) x) (Vopp v y)) = (Vmul v x y).
+Lemma Vmul_opp_opp : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v (Fopp (VF v) x) (Vopp v y)) = (Vmul v x y).
 Proof.
 move=> v x y.
 rewrite (Vopp_mul_distr_l_reverse v x (Vopp v y)).
@@ -452,7 +450,7 @@ rewrite H2.
 reflexivity.
 Qed.
 
-Lemma Vmul_minus_distr_l : forall (v : VectorSpace) (x : FT (F v)) (y z : VT v), (Vmul v x (Vadd v y (Vopp v z))) = (Vadd v (Vmul v x y) (Vopp v (Vmul v x z))).
+Lemma Vmul_minus_distr_l : forall (v : VectorSpace) (x : FT (VF v)) (y z : VT v), (Vmul v x (Vadd v y (Vopp v z))) = (Vadd v (Vmul v x y) (Vopp v (Vmul v x z))).
 Proof.
 move=> v x y z.
 rewrite (Vmul_add_distr_l v x y (Vopp v z)).


### PR DESCRIPTION
## 概要
ベクトル空間の体が`F`だと使いづらいので`VF`に変更。