### PR TITLE
ベクトル空間を修正

### DIFF
--- a/Analysis/KaisekiNyuumonn/KaisekiNyuumonn1.v
+++ b/Analysis/KaisekiNyuumonn/KaisekiNyuumonn1.v
@@ -7594,7 +7594,7 @@ Lemma Proposition_4_2_4_3 : forall (N : nat) (x : Rn N), x = (RnO N) -> (RnInner
 Proof.
 move=> N x H1.
 rewrite H1.
-have: Rnmult N 0 (RnO N) = (Vmul (RnVS N) 0 (RnO N)).
+have: Rnmult N 0 (RnO N) = (Vmul Rfield (RnVS N) 0 (RnO N)).
 simpl.
 reflexivity.
 move=> H2.
@@ -7604,7 +7604,7 @@ rewrite {2} H3.
 rewrite - (Proposition_4_2_2_2 N 0 (RnO N) (RnO N)).
 apply (Rmult_0_l (RnInnerProduct N (RnO N) (RnO N))).
 rewrite H2.
-rewrite (Vmul_O_l (RnVS N) (RnO N)).
+rewrite (Vmul_O_l Rfield (RnVS N) (RnO N)).
 reflexivity.
 Qed.
 
@@ -7657,16 +7657,16 @@ rewrite (Proposition_4_2_1_2 N (Rnopp N y) x (Rnopp N y)).
 rewrite (Rplus_assoc (RnInnerProduct N x x) (RnInnerProduct N x (Rnopp N y)) (RnInnerProduct N (Rnopp N y) x + RnInnerProduct N (Rnopp N y) (Rnopp N y))).
 rewrite (Rplus_assoc (RnInnerProduct N x x) (- (2 * RnInnerProduct N x y)) (RnInnerProduct N y y)).
 apply (Rplus_eq_compat_l (RnInnerProduct N x x) (RnInnerProduct N x (Rnopp N y) + (RnInnerProduct N (Rnopp N y) x + RnInnerProduct N (Rnopp N y) (Rnopp N y))) (- (2 * RnInnerProduct N x y) + RnInnerProduct N y y)).
-rewrite - (Vmul_I_l (RnVS N) (Rnopp N y)).
+rewrite - (Vmul_I_l Rfield (RnVS N) (Rnopp N y)).
 simpl.
-have: ((Rnmult N 1 (Rnopp N y)) = (Vmul (RnVS N) 1 (Vopp (RnVS N) y))).
+have: ((Rnmult N 1 (Rnopp N y)) = (Vmul Rfield (RnVS N) 1 (Vopp Rfield (RnVS N) y))).
 simpl.
 reflexivity.
 move=> H1.
 rewrite H1.
-rewrite - (Vopp_mul_distr_r (RnVS N) 1 y).
-rewrite (Vopp_mul_distr_l (RnVS N) 1 y).
-have: ((Rnmult N (- 1) y) = (Vmul (RnVS N) (Fopp (VF (RnVS N)) 1) y)).
+rewrite - (Vopp_mul_distr_r Rfield (RnVS N) 1 y).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) 1 y).
+have: ((Rnmult N (- 1) y) = (Vmul Rfield (RnVS N) (Fopp Rfield 1) y)).
 simpl.
 reflexivity.
 move=> H2.
@@ -8067,12 +8067,12 @@ apply (Rmult_0_l (RnInnerProduct N (RnO N) (RnO N))).
 rewrite H2.
 rewrite (Proposition_4_2_2_1 N 0 (RnO N) y).
 apply (Rmult_0_l (RnInnerProduct N (RnO N) y)).
-have: Rnmult N 0 (RnO N) = (Vmul (RnVS N) 0 (RnO N)).
+have: Rnmult N 0 (RnO N) = (Vmul Rfield (RnVS N) 0 (RnO N)).
 simpl.
 reflexivity.
 move=> H2.
 rewrite H2.
-rewrite (Vmul_O_l (RnVS N) (RnO N)).
+rewrite (Vmul_O_l Rfield (RnVS N) (RnO N)).
 simpl.
 reflexivity.
 move=> H2.
@@ -8223,10 +8223,10 @@ elim (classic ((RnInnerProduct N x x) = 0)).
 move=> H2.
 exists 0.
 left.
-suff: ((Rnmult N 0 y) = (Vmul (RnVS N) (FO (VF (RnVS N))) y)).
+suff: ((Rnmult N 0 y) = (Vmul Rfield (RnVS N) (FO Rfield) y)).
 move=> H3.
 rewrite H3.
-rewrite (Vmul_O_l (RnVS N) y).
+rewrite (Vmul_O_l Rfield (RnVS N) y).
 simpl.
 apply (Proposition_4_2_4_2 N x H2).
 simpl.
@@ -8347,7 +8347,7 @@ move=> H6.
 apply H3.
 exists t.
 right.
-apply (Vminus_diag_uniq_sym (RnVS N) y (Rnmult N t x)).
+apply (Vminus_diag_uniq_sym Rfield (RnVS N) y (Rnmult N t x)).
 apply H6.
 apply (Proposition_4_2_4_2 N (Rnminus N (Rnmult N t x) y)).
 rewrite (proj2 (RnNormNature N (Rnminus N (Rnmult N t x) y))).
@@ -8677,14 +8677,14 @@ Qed.
 Lemma Rn_dist_sym : forall (N : nat) (x y : Rn N), Rn_dist N x y = Rn_dist N y x.
 Proof.
 move=> N x y.
-have: (Rnminus N y x) = (Vadd (RnVS N) y (Vopp (RnVS N) x)).
+have: (Rnminus N y x) = (Vadd Rfield (RnVS N) y (Vopp Rfield (RnVS N) x)).
 reflexivity.
 move=> H1.
 unfold Rn_dist.
 rewrite H1.
-rewrite - (Vopp_minus_distr (RnVS N) x y).
-rewrite - (Vmul_I_l (RnVS N) (Vadd (RnVS N) x (Vopp (RnVS N) y))).
-rewrite (Vopp_mul_distr_l (RnVS N) (FI (VF (RnVS N))) (Vadd (RnVS N) x (Vopp (RnVS N) y))).
+rewrite - (Vopp_minus_distr Rfield (RnVS N) x y).
+rewrite - (Vmul_I_l Rfield (RnVS N) (Vadd Rfield (RnVS N) x (Vopp Rfield (RnVS N) y))).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) (FI Rfield) (Vadd Rfield (RnVS N) x (Vopp Rfield (RnVS N) y))).
 simpl.
 rewrite (Proposition_4_4_1 N (- 1) (Rnplus N x (Rnopp N y))).
 rewrite (Rabs_Ropp 1).
@@ -8698,7 +8698,7 @@ Proof.
 move=> N x y.
 apply conj.
 move=> H1.
-apply (Vminus_diag_uniq (RnVS N) x y).
+apply (Vminus_diag_uniq Rfield (RnVS N) x y).
 simpl.
 apply (Proposition_4_4_3_2 N (Rnplus N x (Rnopp N y))).
 apply H1.
@@ -8730,11 +8730,11 @@ unfold Rnminus.
 rewrite - (Rnplus_assoc N (Rnplus N x (Rnopp N z)) z (Rnopp N y)).
 rewrite (Rnplus_assoc N x (Rnopp N z) z).
 have: Rnplus N (Rnopp N z) z = RnO N.
-apply (Vadd_opp_l (RnVS N) z).
+apply (Vadd_opp_l Rfield (RnVS N) z).
 move=> H1.
 rewrite H1.
 have: (Rnplus N x (RnO N)) = x.
-apply (Vadd_O_r (RnVS N) x).
+apply (Vadd_O_r Rfield (RnVS N) x).
 move=> H2.
 rewrite H2.
 reflexivity.
@@ -10424,7 +10424,7 @@ rewrite sum_f_Rn_component.
 reflexivity.
 Qed.
 
-Definition RnPCM (N : nat) : CommutativeMonoid := mkCommutativeMonoid (Rn N) (RnO N) (Rnplus N) (Rnplus_comm N) (Vadd_O_r (RnVS N)) (Rnplus_assoc N).
+Definition RnPCM (N : nat) : CommutativeMonoid := mkCommutativeMonoid (Rn N) (RnO N) (Rnplus N) (Rnplus_comm N) (Vadd_O_r Rfield (RnVS N)) (Rnplus_assoc N).
 
 Lemma MySumF2RPNCM_component : forall (N : nat) (U : Type) (A : {X : Ensemble U | Finite U X}) (f : U -> Rn N), MySumF2 U A (RnPCM N) f = (fun (m : Count N) => MySumF2 U A RPCM (fun (n : U) => f n m)).
 Proof.
@@ -10737,10 +10737,10 @@ move=> n H4.
 unfold dist.
 unfold Rn_met.
 unfold Rn_dist.
-suff: (Rnminus N (an n) (RnO N) = Vadd (RnVS N) (an n) (Vopp (RnVS N) (VO (RnVS N)))).
+suff: (Rnminus N (an n) (RnO N) = Vadd Rfield (RnVS N) (an n) (Vopp Rfield (RnVS N) (VO Rfield (RnVS N)))).
 move=> H5.
 rewrite H5.
-rewrite (Vminus_O_r (RnVS N) (an n)).
+rewrite (Vminus_O_r Rfield (RnVS N) (an n)).
 move: H4.
 elim n.
 move=> H6.
@@ -11017,10 +11017,10 @@ apply (FiniteSetInduction U A).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
-suff: (Rnmult N c (CMe (RnPCM N)) = (Vmul (RnVS N) c (VO (RnVS N)))).
+suff: (Rnmult N c (CMe (RnPCM N)) = (Vmul Rfield (RnVS N) c (VO Rfield (RnVS N)))).
 move=> H1.
 rewrite H1.
-rewrite (Vmul_O_r (RnVS N) c).
+rewrite (Vmul_O_r Rfield (RnVS N) c).
 reflexivity.
 reflexivity.
 move=> B b H1 H2 H3 H4.
@@ -11602,7 +11602,7 @@ rewrite Rnplus_assoc.
 rewrite (Rnplus_comm N a (Rnplus N (sum_f_Rn N Bn M1) (Rnopp N (sum_f_Rn N An M1)))).
 unfold Rnminus.
 rewrite Rnplus_assoc.
-suff: (Rnopp N (Rnplus N (Rnplus N (sum_f_Rn N Bn M1) (Rnopp N (sum_f_Rn N An M1))) a) = Vopp (RnVS N) (Vadd (RnVS N) (Rnplus N (sum_f_Rn N Bn M1) (Rnopp N (sum_f_Rn N An M1))) a)).
+suff: (Rnopp N (Rnplus N (Rnplus N (sum_f_Rn N Bn M1) (Rnopp N (sum_f_Rn N An M1))) a) = Vopp Rfield (RnVS N) (Vadd Rfield (RnVS N) (Rnplus N (sum_f_Rn N Bn M1) (Rnopp N (sum_f_Rn N An M1))) a)).
 move=> H10.
 rewrite H10.
 rewrite Vopp_add_distr.
@@ -12632,7 +12632,7 @@ unfold dist.
 unfold Rn_met.
 unfold Rn_dist.
 unfold Rnminus.
-suff: ((Rnopp N (Rnplus N s (Rnopp N (sum_f_Rn N an k)))) = Vopp (RnVS N) (Vadd (RnVS N) s (Rnopp N (sum_f_Rn N an k)))).
+suff: ((Rnopp N (Rnplus N s (Rnopp N (sum_f_Rn N an k)))) = Vopp Rfield (RnVS N) (Vadd Rfield (RnVS N) s (Rnopp N (sum_f_Rn N an k)))).
 move=> H6.
 rewrite H6.
 rewrite Vopp_add_distr.
@@ -12665,8 +12665,8 @@ unfold Rnminus.
 rewrite Rnplus_assoc.
 rewrite Rnplus_comm.
 rewrite Rnplus_assoc.
-rewrite - (Vopp_involutive (RnVS N) (sum_f_Rn N an k)).
-suff: ((Rnplus N (Rnopp N s) (Vopp (RnVS N) (Vopp (RnVS N) (sum_f_Rn N an k)))) = Vadd (RnVS N) (Vopp (RnVS N) s) (Vopp (RnVS N) (Vopp (RnVS N) (sum_f_Rn N an k)))).
+rewrite - (Vopp_involutive Rfield (RnVS N) (sum_f_Rn N an k)).
+suff: ((Rnplus N (Rnopp N s) (Vopp Rfield (RnVS N) (Vopp Rfield (RnVS N) (sum_f_Rn N an k)))) = Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) s) (Vopp Rfield (RnVS N) (Vopp Rfield (RnVS N) (sum_f_Rn N an k)))).
 move=> H7.
 rewrite H7.
 rewrite - Vopp_add_distr.
@@ -18451,7 +18451,7 @@ Proof.
 move=> T N f.
 apply functional_extensionality.
 move=> x.
-apply (Vadd_O_r (RnVS N)).
+apply (Vadd_O_r Rfield (RnVS N)).
 Qed.
 
 Lemma RnFplus_assoc : forall (T : Type) (N : nat) (f g h : T -> Rn N), (RnFplus T N (RnFplus T N f g) h) = (RnFplus T N f (RnFplus T N g h)).
@@ -19169,14 +19169,14 @@ apply (H3 (an n)).
 apply (H2 n).
 unfold Rn_dist.
 unfold Rnminus.
-suff: ((Rnopp N (RnO N)) = (Vopp (RnVS N) (VO (RnVS N)))).
+suff: ((Rnopp N (RnO N)) = (Vopp Rfield (RnVS N) (VO Rfield (RnVS N)))).
 move=> H9.
 rewrite H9.
-rewrite (Vopp_O (RnVS N)).
-suff: ((Rnplus N (an n) (VO (RnVS N))) = (Vadd (RnVS N) (an n) (VO (RnVS N)))).
+rewrite (Vopp_O Rfield (RnVS N)).
+suff: ((Rnplus N (an n) (VO Rfield (RnVS N))) = (Vadd Rfield (RnVS N) (an n) (VO Rfield (RnVS N)))).
 move=> H10.
 rewrite H10.
-rewrite (Vadd_O_r (RnVS N) (an n)).
+rewrite (Vadd_O_r Rfield (RnVS N) (an n)).
 reflexivity.
 reflexivity.
 reflexivity.
@@ -19914,11 +19914,11 @@ apply (Rge_le (RnNorm N a) 0).
 apply (proj1 (RnNormNature N a)).
 apply H11.
 apply H11.
-suff: (Rnplus N a (Rnopp N (RnO N)) = Vadd (RnVS N) a (Vopp (RnVS N) (VO (RnVS N)))).
+suff: (Rnplus N a (Rnopp N (RnO N)) = Vadd Rfield (RnVS N) a (Vopp Rfield (RnVS N) (VO Rfield (RnVS N)))).
 move=> H10.
 rewrite H10.
-rewrite (Vopp_O (RnVS N)).
-apply (Vadd_O_r (RnVS N) a).
+rewrite (Vopp_O Rfield (RnVS N)).
+apply (Vadd_O_r Rfield (RnVS N) a).
 reflexivity.
 apply (Rlt_le (Rn_dist N a (RnO N)) M).
 apply (H6 a H9).
@@ -23338,23 +23338,23 @@ reflexivity.
 unfold Rnminus.
 rewrite (proj2 H12).
 rewrite (Rnplus_comm N (Rnmult N (1 - t) a) (Rnmult N t r)).
-suff: (Rnplus N (Rnplus N (Rnmult N t r) (Rnmult N (1 - t) a)) (Rnopp N r) = Vadd (RnVS N) (Vadd (RnVS N) (Vmul (RnVS N) t r) (Vmul (RnVS N) (1 - t) a)) (Vopp (RnVS N) r)).
+suff: (Rnplus N (Rnplus N (Rnmult N t r) (Rnmult N (1 - t) a)) (Rnopp N r) = Vadd Rfield (RnVS N) (Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) t r) (Vmul Rfield (RnVS N) (1 - t) a)) (Vopp Rfield (RnVS N) r)).
 move=> H13.
 rewrite H13.
-suff: (Rnmult N (1 - t) (Rnplus N a (Rnopp N r)) = Vmul (RnVS N) (1 - t) (Vadd (RnVS N) a (Vopp (RnVS N) r))).
+suff: (Rnmult N (1 - t) (Rnplus N a (Rnopp N r)) = Vmul Rfield (RnVS N) (1 - t) (Vadd Rfield (RnVS N) a (Vopp Rfield (RnVS N) r))).
 move=> H14.
 rewrite H14.
-rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) t r) (Vmul (RnVS N) (1 - t) a)).
-rewrite (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - t) a) (Vmul (RnVS N) t r) (Vopp (RnVS N) r)).
-rewrite (Vmul_add_distr_l (RnVS N) (1 - t) a (Vopp (RnVS N) r)).
-suff: ((Vadd (RnVS N) (Vmul (RnVS N) t r) (Vopp (RnVS N) r)) = (Vmul (RnVS N) (1 - t) (Vopp (RnVS N) r))).
+rewrite (Vadd_comm Rfield (RnVS N) (Vmul Rfield (RnVS N) t r) (Vmul Rfield (RnVS N) (1 - t) a)).
+rewrite (Vadd_assoc Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - t) a) (Vmul Rfield (RnVS N) t r) (Vopp Rfield (RnVS N) r)).
+rewrite (Vmul_add_distr_l Rfield (RnVS N) (1 - t) a (Vopp Rfield (RnVS N) r)).
+suff: ((Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) t r) (Vopp Rfield (RnVS N) r)) = (Vmul Rfield (RnVS N) (1 - t) (Vopp Rfield (RnVS N) r))).
 move=> H15.
 rewrite H15.
 reflexivity.
-rewrite (Vmul_add_distr_r (RnVS N) 1 (- t) (Vopp (RnVS N) r)).
-rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) t r) (Vopp (RnVS N) r)).
-rewrite (Vmul_I_l (RnVS N) (Vopp (RnVS N) r)).
-rewrite (Vmul_opp_opp (RnVS N) t r).
+rewrite (Vmul_add_distr_r Rfield (RnVS N) 1 (- t) (Vopp Rfield (RnVS N) r)).
+rewrite (Vadd_comm Rfield (RnVS N) (Vmul Rfield (RnVS N) t r) (Vopp Rfield (RnVS N) r)).
+rewrite (Vmul_I_l Rfield (RnVS N) (Vopp Rfield (RnVS N) r)).
+rewrite (Vmul_opp_opp Rfield (RnVS N) t r).
 reflexivity.
 reflexivity.
 reflexivity.
@@ -23404,26 +23404,26 @@ reflexivity.
 apply (Rle_ge 0 t (proj1 (proj1 H11))).
 unfold Rnminus.
 rewrite (proj2 H11).
-suff: (Rnplus N (Rnplus N (Rnmult N (1 - t) r) (Rnmult N t a)) (Rnopp N r) = Vadd (RnVS N) (Vadd (RnVS N) (Vmul (RnVS N) (1 - t) r) (Vmul (RnVS N) t a)) (Vopp (RnVS N) r)).
+suff: (Rnplus N (Rnplus N (Rnmult N (1 - t) r) (Rnmult N t a)) (Rnopp N r) = Vadd Rfield (RnVS N) (Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - t) r) (Vmul Rfield (RnVS N) t a)) (Vopp Rfield (RnVS N) r)).
 move=> H12.
 rewrite H12.
-suff: (Rnmult N t (Rnplus N a (Rnopp N r)) = Vmul (RnVS N) t (Vadd (RnVS N) a (Vopp (RnVS N) r))).
+suff: (Rnmult N t (Rnplus N a (Rnopp N r)) = Vmul Rfield (RnVS N) t (Vadd Rfield (RnVS N) a (Vopp Rfield (RnVS N) r))).
 move=> H13.
 rewrite H13.
-rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) (1 - t) r) (Vmul (RnVS N) t a)).
-rewrite (Vadd_assoc (RnVS N) (Vmul (RnVS N) t a) (Vmul (RnVS N) (1 - t) r) (Vopp (RnVS N) r)).
-rewrite (Vmul_add_distr_l (RnVS N) t a (Vopp (RnVS N) r)).
-suff: ((Vadd (RnVS N) (Vmul (RnVS N) (1 - t) r) (Vopp (RnVS N) r)) = (Vmul (RnVS N) t (Vopp (RnVS N) r))).
+rewrite (Vadd_comm Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - t) r) (Vmul Rfield (RnVS N) t a)).
+rewrite (Vadd_assoc Rfield (RnVS N) (Vmul Rfield (RnVS N) t a) (Vmul Rfield (RnVS N) (1 - t) r) (Vopp Rfield (RnVS N) r)).
+rewrite (Vmul_add_distr_l Rfield (RnVS N) t a (Vopp Rfield (RnVS N) r)).
+suff: ((Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - t) r) (Vopp Rfield (RnVS N) r)) = (Vmul Rfield (RnVS N) t (Vopp Rfield (RnVS N) r))).
 move=> H14.
 rewrite H14.
 reflexivity.
-rewrite - {1} (Vmul_I_l (RnVS N) (Vopp (RnVS N) r)).
-rewrite - (Vopp_mul_distr_r (RnVS N) (FI (VF (RnVS N))) r).
-rewrite (Vopp_mul_distr_l (RnVS N) (FI (VF (RnVS N))) r).
-rewrite - (Vmul_add_distr_r (RnVS N) (1 - t) (Fopp (VF (RnVS N)) (FI (VF (RnVS N)))) r).
-rewrite - (Vopp_mul_distr_r (RnVS N) t r).
-rewrite (Vopp_mul_distr_l (RnVS N) t r).
-suff: ((Fadd (VF (RnVS N)) (1 - t) (Fopp (VF (RnVS N)) (FI (VF (RnVS N))))) = (Fopp (VF (RnVS N)) t)).
+rewrite - {1} (Vmul_I_l Rfield (RnVS N) (Vopp Rfield (RnVS N) r)).
+rewrite - (Vopp_mul_distr_r Rfield (RnVS N) (FI Rfield) r).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) (FI Rfield) r).
+rewrite - (Vmul_add_distr_r Rfield (RnVS N) (1 - t) (Fopp Rfield (FI Rfield)) r).
+rewrite - (Vopp_mul_distr_r Rfield (RnVS N) t r).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) t r).
+suff: ((Fadd Rfield (1 - t) (Fopp Rfield (FI Rfield))) = (Fopp Rfield t)).
 move=> H14.
 rewrite H14.
 reflexivity.
@@ -23504,14 +23504,14 @@ rewrite (Rplus_opp_r b).
 rewrite Ropp_0.
 rewrite (Rplus_0_r 1).
 rewrite (Rnmult_I_l N r02).
-suff: (Rnmult N 0 r03 = Vmul (RnVS N) 0 r03).
+suff: (Rnmult N 0 r03 = Vmul Rfield (RnVS N) 0 r03).
 move=> H10.
 rewrite H10.
-rewrite (Vmul_O_l (RnVS N) r03).
-suff: (Rnplus N r02 (VO (RnVS N)) = Vadd (RnVS N) r02 (VO (RnVS N))).
+rewrite (Vmul_O_l Rfield (RnVS N) r03).
+suff: (Rnplus N r02 (VO Rfield (RnVS N)) = Vadd Rfield (RnVS N) r02 (VO Rfield (RnVS N))).
 move=> H11.
 rewrite H11.
-rewrite (Vadd_O_r (RnVS N) r02).
+rewrite (Vadd_O_r Rfield (RnVS N) r02).
 rewrite - (proj1 H5).
 rewrite - (proj1 (proj2 H5)).
 rewrite H9.
@@ -23537,11 +23537,11 @@ suff: ((b + 1 - b) = 1).
 move=> H10.
 rewrite H10.
 rewrite (Rnmult_I_l N r03).
-suff: (Rnplus N (Rnmult N 0 r02) r03 = Vadd (RnVS N) (Vmul (RnVS N) 0 r02) r03).
+suff: (Rnplus N (Rnmult N 0 r02) r03 = Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) 0 r02) r03).
 move=> H11.
 rewrite H11.
-rewrite (Vmul_O_l (RnVS N) r02).
-apply (Vadd_O_l (RnVS N) r03).
+rewrite (Vmul_O_l Rfield (RnVS N) r02).
+apply (Vadd_O_l Rfield (RnVS N) r03).
 reflexivity.
 unfold Rminus.
 rewrite (Rplus_comm (b + 1) (- b)).
@@ -23700,8 +23700,8 @@ suff: ((Rnmult N 0 r03) = RnO N).
 move=> H19.
 rewrite H19.
 rewrite (proj1 (proj2 H5)).
-apply (Vadd_O_r (RnVS N) r02).
-apply (Vmul_O_l (RnVS N) r03).
+apply (Vadd_O_r Rfield (RnVS N) r02).
+apply (Vmul_O_l Rfield (RnVS N) r03).
 move=> H17.
 elim (Rlt_le_dec r b).
 move=> H18.
@@ -23838,30 +23838,30 @@ move=> H13.
 apply H8.
 apply (proj1 (dist_refl (Rn_met N) r02 r03) H13).
 unfold Rnminus.
-suff: (Rnplus N (Rnplus N (Rnmult N (1 - (y - b)) r02) (Rnmult N (y - b) r03)) (Rnopp N (Rnplus N (Rnmult N (1 - (r - b)) r02) (Rnmult N (r - b) r03))) = Vadd (RnVS N) (Vadd (RnVS N) (Vmul (RnVS N) (1 - (y - b)) r02) (Vmul (RnVS N) (y - b) r03)) (Vopp (RnVS N) (Vadd (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02) (Vmul (RnVS N) (r - b) r03)))).
+suff: (Rnplus N (Rnplus N (Rnmult N (1 - (y - b)) r02) (Rnmult N (y - b) r03)) (Rnopp N (Rnplus N (Rnmult N (1 - (r - b)) r02) (Rnmult N (r - b) r03))) = Vadd Rfield (RnVS N) (Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (y - b)) r02) (Vmul Rfield (RnVS N) (y - b) r03)) (Vopp Rfield (RnVS N) (Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (r - b)) r02) (Vmul Rfield (RnVS N) (r - b) r03)))).
 move=> H12.
 rewrite H12.
-suff: (Rnmult N (r - y) (Rnplus N r02 (Rnopp N r03)) = Vmul (RnVS N) (r - y) (Vadd (RnVS N) r02 (Vopp (RnVS N) r03))).
+suff: (Rnmult N (r - y) (Rnplus N r02 (Rnopp N r03)) = Vmul Rfield (RnVS N) (r - y) (Vadd Rfield (RnVS N) r02 (Vopp Rfield (RnVS N) r03))).
 move=> H13.
 rewrite H13.
-rewrite (Vopp_add_distr (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02) (Vmul (RnVS N) (r - b) r03)).
-rewrite (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - (y - b)) r02) (Vmul (RnVS N) (y - b) r03) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02)) (Vopp (RnVS N) (Vmul (RnVS N) (r - b) r03)))).
-rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) (y - b) r03) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02)) (Vopp (RnVS N) (Vmul (RnVS N) (r - b) r03)))).
-rewrite (Vadd_assoc (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02)) (Vopp (RnVS N) (Vmul (RnVS N) (r - b) r03)) (Vmul (RnVS N) (y - b) r03)).
-rewrite - (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - (y - b)) r02) (Vopp (RnVS N) (Vmul (RnVS N) (1 - (r - b)) r02)) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (r - b) r03)) (Vmul (RnVS N) (y - b) r03))).
-rewrite (Vopp_mul_distr_l (RnVS N) (1 - (r - b)) r02).
-rewrite - (Vmul_add_distr_r (RnVS N) (1 - (y - b)) (Fopp (VF (RnVS N)) (1 - (r - b))) r02).
-suff: ((Fadd (VF (RnVS N)) (1 - (y - b)) (Fopp (VF (RnVS N)) (1 - (r - b)))) = r - y).
+rewrite (Vopp_add_distr Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (r - b)) r02) (Vmul Rfield (RnVS N) (r - b) r03)).
+rewrite (Vadd_assoc Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (y - b)) r02) (Vmul Rfield (RnVS N) (y - b) r03) (Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (r - b)) r02)) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (r - b) r03)))).
+rewrite (Vadd_comm Rfield (RnVS N) (Vmul Rfield (RnVS N) (y - b) r03) (Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (r - b)) r02)) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (r - b) r03)))).
+rewrite (Vadd_assoc Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (r - b)) r02)) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (r - b) r03)) (Vmul Rfield (RnVS N) (y - b) r03)).
+rewrite - (Vadd_assoc Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (y - b)) r02) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - (r - b)) r02)) (Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (r - b) r03)) (Vmul Rfield (RnVS N) (y - b) r03))).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) (1 - (r - b)) r02).
+rewrite - (Vmul_add_distr_r Rfield (RnVS N) (1 - (y - b)) (Fopp Rfield (1 - (r - b))) r02).
+suff: ((Fadd Rfield (1 - (y - b)) (Fopp Rfield (1 - (r - b)))) = r - y).
 move=> H14.
 rewrite H14.
-rewrite (Vopp_mul_distr_l (RnVS N) (r - b) r03).
-rewrite - (Vmul_add_distr_r (RnVS N) (Fopp (VF (RnVS N)) (r - b)) (y - b) r03).
-suff: ((Fadd (VF (RnVS N)) (Fopp (VF (RnVS N)) (r - b)) (y - b)) = - (r - y)).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) (r - b) r03).
+rewrite - (Vmul_add_distr_r Rfield (RnVS N) (Fopp Rfield (r - b)) (y - b) r03).
+suff: ((Fadd Rfield (Fopp Rfield (r - b)) (y - b)) = - (r - y)).
 move=> H15.
 rewrite H15.
-rewrite - (Vopp_mul_distr_l (RnVS N) (r - y) r03).
-rewrite (Vopp_mul_distr_r (RnVS N) (r - y) r03).
-rewrite (Vmul_add_distr_l (RnVS N) (r - y) r02 (Vopp (RnVS N) r03)).
+rewrite - (Vopp_mul_distr_l Rfield (RnVS N) (r - y) r03).
+rewrite (Vopp_mul_distr_r Rfield (RnVS N) (r - y) r03).
+rewrite (Vmul_add_distr_l Rfield (RnVS N) (r - y) r02 (Vopp Rfield (RnVS N) r03)).
 reflexivity.
 simpl.
 rewrite (Ropp_minus_distr r b).
@@ -24222,8 +24222,8 @@ rewrite (Rnmult_I_l N x).
 suff: ((Rnmult N 0 y) = RnO N).
 move=> H4.
 rewrite H4.
-apply (Vadd_O_r (RnVS N) x).
-apply (Vmul_O_l (RnVS N) y).
+apply (Vadd_O_r Rfield (RnVS N) x).
+apply (Vmul_O_l Rfield (RnVS N) y).
 apply conj.
 unfold Rminus.
 rewrite (Rplus_opp_r 1).
@@ -24231,8 +24231,8 @@ rewrite (Rnmult_I_l N y).
 suff: ((Rnmult N 0 x) = RnO N).
 move=> H4.
 rewrite H4.
-apply (Vadd_O_l (RnVS N) y).
-apply (Vmul_O_l (RnVS N) x).
+apply (Vadd_O_l Rfield (RnVS N) y).
+apply (Vmul_O_l Rfield (RnVS N) x).
 apply conj.
 move=> r H4.
 apply (Full_intro (Rn N) (Rnplus N (Rnmult N (1 - r) x) (Rnmult N r y))).
@@ -24292,30 +24292,30 @@ move=> H9.
 apply H6.
 apply (proj1 (dist_refl (Rn_met N) x y) H9).
 unfold Rnminus.
-suff: (Rnplus N (Rnplus N (Rnmult N (1 - z) x) (Rnmult N z y)) (Rnopp N (Rnplus N (Rnmult N (1 - r) x) (Rnmult N r y))) = Vadd (RnVS N) (Vadd (RnVS N) (Vmul (RnVS N) (1 - z) x) (Vmul (RnVS N) z y)) (Vopp (RnVS N) (Vadd (RnVS N) (Vmul (RnVS N) (1 - r) x) (Vmul (RnVS N) r y)))).
+suff: (Rnplus N (Rnplus N (Rnmult N (1 - z) x) (Rnmult N z y)) (Rnopp N (Rnplus N (Rnmult N (1 - r) x) (Rnmult N r y))) = Vadd Rfield (RnVS N) (Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - z) x) (Vmul Rfield (RnVS N) z y)) (Vopp Rfield (RnVS N) (Vadd Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - r) x) (Vmul Rfield (RnVS N) r y)))).
 move=> H8.
 rewrite H8.
-suff: (Rnmult N (r - z) (Rnplus N x (Rnopp N y)) = Vmul (RnVS N) (r - z) (Vadd (RnVS N) x (Vopp (RnVS N) y))).
+suff: (Rnmult N (r - z) (Rnplus N x (Rnopp N y)) = Vmul Rfield (RnVS N) (r - z) (Vadd Rfield (RnVS N) x (Vopp Rfield (RnVS N) y))).
 move=> H9.
 rewrite H9.
-rewrite (Vopp_add_distr (RnVS N) (Vmul (RnVS N) (1 - r) x) (Vmul (RnVS N) r y)).
-rewrite (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - z) x) (Vmul (RnVS N) z y) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - r) x)) (Vopp (RnVS N) (Vmul (RnVS N) r y)))).
-rewrite (Vadd_comm (RnVS N) (Vmul (RnVS N) z y) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - r) x)) (Vopp (RnVS N) (Vmul (RnVS N) r y)))).
-rewrite (Vadd_assoc (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) (1 - r) x)) (Vopp (RnVS N) (Vmul (RnVS N) r y)) (Vmul (RnVS N) z y)).
-rewrite - (Vadd_assoc (RnVS N) (Vmul (RnVS N) (1 - z) x) (Vopp (RnVS N) (Vmul (RnVS N) (1 - r) x)) (Vadd (RnVS N) (Vopp (RnVS N) (Vmul (RnVS N) r y)) (Vmul (RnVS N) z y))).
-rewrite (Vopp_mul_distr_l (RnVS N) (1 - r) x).
-rewrite - (Vmul_add_distr_r (RnVS N) (1 - z) (Fopp (VF (RnVS N)) (1 - r)) x).
-suff: ((Fadd (VF (RnVS N)) (1 - z) (Fopp (VF (RnVS N)) (1 - r))) = r - z).
+rewrite (Vopp_add_distr Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - r) x) (Vmul Rfield (RnVS N) r y)).
+rewrite (Vadd_assoc Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - z) x) (Vmul Rfield (RnVS N) z y) (Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - r) x)) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) r y)))).
+rewrite (Vadd_comm Rfield (RnVS N) (Vmul Rfield (RnVS N) z y) (Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - r) x)) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) r y)))).
+rewrite (Vadd_assoc Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - r) x)) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) r y)) (Vmul Rfield (RnVS N) z y)).
+rewrite - (Vadd_assoc Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - z) x) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) (1 - r) x)) (Vadd Rfield (RnVS N) (Vopp Rfield (RnVS N) (Vmul Rfield (RnVS N) r y)) (Vmul Rfield (RnVS N) z y))).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) (1 - r) x).
+rewrite - (Vmul_add_distr_r Rfield (RnVS N) (1 - z) (Fopp Rfield (1 - r)) x).
+suff: ((Fadd Rfield (1 - z) (Fopp Rfield (1 - r))) = r - z).
 move=> H10.
 rewrite H10.
-rewrite (Vopp_mul_distr_l (RnVS N) r y).
-rewrite - (Vmul_add_distr_r (RnVS N) (Fopp (VF (RnVS N)) r) z y).
-suff: ((Fadd (VF (RnVS N)) (Fopp (VF (RnVS N)) r) z) = - (r - z)).
+rewrite (Vopp_mul_distr_l Rfield (RnVS N) r y).
+rewrite - (Vmul_add_distr_r Rfield (RnVS N) (Fopp Rfield r) z y).
+suff: ((Fadd Rfield (Fopp Rfield r) z) = - (r - z)).
 move=> H11.
 rewrite H11.
-rewrite - (Vopp_mul_distr_l (RnVS N) (r - z) y).
-rewrite (Vopp_mul_distr_r (RnVS N) (r - z) y).
-rewrite (Vmul_add_distr_l (RnVS N) (r - z) x (Vopp (RnVS N) y)).
+rewrite - (Vopp_mul_distr_l Rfield (RnVS N) (r - z) y).
+rewrite (Vopp_mul_distr_r Rfield (RnVS N) (r - z) y).
+rewrite (Vmul_add_distr_l Rfield (RnVS N) (r - z) x (Vopp Rfield (RnVS N) y)).
 reflexivity.
 simpl.
 rewrite (Ropp_minus_distr r z).

--- a/MyAlgebraicStructure/MyVectorSpace.v
+++ b/MyAlgebraicStructure/MyVectorSpace.v
@@ -8,190 +8,189 @@ Require Import MyAlgebraicStructure.MyField.
 
 Section VectorSpace.
 
-Record VectorSpace : Type := mkVectorSpace
+Record VectorSpace (F : Field) : Type := mkVectorSpace
 {
-VF   : Field;
 VT   : Type;
 VO : VT;
 Vadd : VT -> VT -> VT;
-Vmul : (FT VF) -> VT -> VT;
+Vmul : (FT F) -> VT -> VT;
 Vopp : VT -> VT;
 Vadd_comm : forall (x y : VT), (Vadd x y) = (Vadd y x);
 Vadd_assoc : forall (x y z : VT), (Vadd (Vadd x y) z) = (Vadd x (Vadd y z));
 Vadd_O_l : forall x : VT, (Vadd VO x) = x;
 Vadd_opp_r : forall x : VT, (Vadd x (Vopp x)) = VO;
-Vmul_add_distr_l : forall (x : FT VF) (y z : VT), (Vmul x (Vadd y z)) = (Vadd (Vmul x y) (Vmul x z));
-Vmul_add_distr_r : forall (x y : FT VF) (z : VT), (Vmul (Fadd VF x y) z) = (Vadd (Vmul x z) (Vmul y z));
-Vmul_assoc : forall (x y : FT VF) (z : VT), (Vmul x (Vmul y z)) = (Vmul (Fmul VF x y) z);
-Vmul_I_l : forall x : VT, (Vmul (FI VF) x) = x;
+Vmul_add_distr_l : forall (x : FT F) (y z : VT), (Vmul x (Vadd y z)) = (Vadd (Vmul x y) (Vmul x z));
+Vmul_add_distr_r : forall (x y : FT F) (z : VT), (Vmul (Fadd F x y) z) = (Vadd (Vmul x z) (Vmul y z));
+Vmul_assoc : forall (x y : FT F) (z : VT), (Vmul x (Vmul y z)) = (Vmul (Fmul F x y) z);
+Vmul_I_l : forall x : VT, (Vmul (FI F) x) = x;
 }.
 
-Lemma Vadd_O_r : forall (v : VectorSpace) (x : VT v), (Vadd v x (VO v)) = x.
+Lemma Vadd_O_r : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vadd F v x (VO F v)) = x.
 Proof.
-move=> v x.
-rewrite (Vadd_comm v x (VO v)).
-apply (Vadd_O_l v x).
+move=> F v x.
+rewrite (Vadd_comm F v x (VO F v)).
+apply (Vadd_O_l F v x).
 Qed.
 
-Lemma Vadd_ne : forall (v : VectorSpace) (x : VT v), (Vadd v x (VO v)) = x /\ (Vadd v (VO v) x) = x.
+Lemma Vadd_ne : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vadd F v x (VO F v)) = x /\ (Vadd F v (VO F v) x) = x.
 Proof.
-move=> v x.
+move=> F v x.
 apply conj.
-apply (Vadd_O_r v x).
-apply (Vadd_O_l v x).
+apply (Vadd_O_r F v x).
+apply (Vadd_O_l F v x).
 Qed.
 
-Lemma Vadd_opp_l : forall (v : VectorSpace) (x : VT v), (Vadd v (Vopp v x) x) = (VO v).
+Lemma Vadd_opp_l : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vadd F v (Vopp F v x) x) = (VO F v).
 Proof.
-move=> v x.
-rewrite (Vadd_comm v (Vopp v x) x).
-apply (Vadd_opp_r v x).
+move=> F v x.
+rewrite (Vadd_comm F v (Vopp F v x) x).
+apply (Vadd_opp_r F v x).
 Qed.
 
-Lemma Vadd_opp_r_uniq : forall (v : VectorSpace) (x y : VT v), (Vadd v x y) = (VO v) -> y = (Vopp v x).
+Lemma Vadd_opp_r_uniq : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v x y) = (VO F v) -> y = (Vopp F v x).
 Proof.
-move=> v x y H1.
-suff: (Vadd v (Vopp v x) (Vadd v x y)) = (Vadd v (Vopp v x) (VO v)).
+move=> F v x y H1.
+suff: (Vadd F v (Vopp F v x) (Vadd F v x y)) = (Vadd F v (Vopp F v x) (VO F v)).
 move=> H2.
-rewrite - (Vadd_O_r v (Vopp v x)).
+rewrite - (Vadd_O_r F v (Vopp F v x)).
 rewrite - H2.
-rewrite - (Vadd_assoc v (Vopp v x) x y).
-rewrite (Vadd_opp_l v x).
-rewrite (Vadd_O_l v y).
+rewrite - (Vadd_assoc F v (Vopp F v x) x y).
+rewrite (Vadd_opp_l F v x).
+rewrite (Vadd_O_l F v y).
 by [].
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vadd_eq_compat_l : forall (v : VectorSpace) (x y z : VT v), y = z -> (Vadd v x y) = (Vadd v x z).
+Lemma Vadd_eq_compat_l : forall (F : Field) (v : VectorSpace F) (x y z : VT F v), y = z -> (Vadd F v x y) = (Vadd F v x z).
 Proof.
-move=> v x y z H1.
+move=> F v x y z H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vadd_eq_compat_r : forall (v : VectorSpace) (x y z : VT v), y = z -> (Vadd v y x) = (Vadd v z x).
+Lemma Vadd_eq_compat_r : forall (F : Field) (v : VectorSpace F) (x y z : VT F v), y = z -> (Vadd F v y x) = (Vadd F v z x).
 Proof.
-move=> v x y z H1.
+move=> F v x y z H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vadd_eq_reg_l : forall (v : VectorSpace) (x y z : VT v), (Vadd v x y) = (Vadd v x z) -> y = z.
+Lemma Vadd_eq_reg_l : forall (F : Field) (v : VectorSpace F) (x y z : VT F v), (Vadd F v x y) = (Vadd F v x z) -> y = z.
 Proof.
-move=> v x y z H1.
-rewrite - (Vadd_O_l v y).
-rewrite - (Vadd_O_l v z).
-rewrite - (Vadd_opp_l v x).
-rewrite (Vadd_assoc v (Vopp v x) x y).
-rewrite (Vadd_assoc v (Vopp v x) x z).
-apply (Vadd_eq_compat_l v (Vopp v x) (Vadd v x y) (Vadd v x z)).
+move=> F v x y z H1.
+rewrite - (Vadd_O_l F v y).
+rewrite - (Vadd_O_l F v z).
+rewrite - (Vadd_opp_l F v x).
+rewrite (Vadd_assoc F v (Vopp F v x) x y).
+rewrite (Vadd_assoc F v (Vopp F v x) x z).
+apply (Vadd_eq_compat_l F v (Vopp F v x) (Vadd F v x y) (Vadd F v x z)).
 by [].
 Qed.
 
-Lemma Vadd_eq_reg_r : forall (v : VectorSpace) (x y z : VT v), (Vadd v y x) = (Vadd v z x) -> y = z.
+Lemma Vadd_eq_reg_r : forall (F : Field) (v : VectorSpace F) (x y z : VT F v), (Vadd F v y x) = (Vadd F v z x) -> y = z.
 Proof.
-move=> v x y z H1.
-rewrite - (Vadd_O_r v y).
-rewrite - (Vadd_O_r v z).
-rewrite - (Vadd_opp_r v x).
-rewrite - (Vadd_assoc v y x (Vopp v x)).
-rewrite - (Vadd_assoc v z x (Vopp v x)).
-apply (Vadd_eq_compat_r v (Vopp v x) (Vadd v y x) (Vadd v z x)).
+move=> F v x y z H1.
+rewrite - (Vadd_O_r F v y).
+rewrite - (Vadd_O_r F v z).
+rewrite - (Vadd_opp_r F v x).
+rewrite - (Vadd_assoc F v y x (Vopp F v x)).
+rewrite - (Vadd_assoc F v z x (Vopp F v x)).
+apply (Vadd_eq_compat_r F v (Vopp F v x) (Vadd F v y x) (Vadd F v z x)).
 by [].
 Qed.
 
-Lemma Vadd_O_r_uniq : forall (v : VectorSpace) (x y : VT v), (Vadd v x y) = x -> y = (VO v).
+Lemma Vadd_O_r_uniq : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v x y) = x -> y = (VO F v).
 Proof.
-move=> v x y H1.
-rewrite - (Vadd_O_l v y).
-rewrite - (Vadd_opp_l v x).
-rewrite (Vadd_assoc v (Vopp v x) x y).
+move=> F v x y H1.
+rewrite - (Vadd_O_l F v y).
+rewrite - (Vadd_opp_l F v x).
+rewrite (Vadd_assoc F v (Vopp F v x) x y).
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_O_r : forall (v : VectorSpace) (x : FT (VF v)), (Vmul v x (VO v)) = (VO v).
+Lemma Vmul_O_r : forall (F : Field) (v : VectorSpace F) (x : FT F), (Vmul F v x (VO F v)) = (VO F v).
 Proof.
-move=> v x.
-apply (Vadd_O_r_uniq v (Vmul v x (VO v)) (Vmul v x (VO v))).
-rewrite - (Vmul_add_distr_l v x (VO v) (VO v)).
-rewrite (Vadd_O_l v (VO v)).
+move=> F v x.
+apply (Vadd_O_r_uniq F v (Vmul F v x (VO F v)) (Vmul F v x (VO F v))).
+rewrite - (Vmul_add_distr_l F v x (VO F v) (VO F v)).
+rewrite (Vadd_O_l F v (VO F v)).
 by [].
 Qed.
 
-Lemma Vmul_O_l : forall (v : VectorSpace) (x : VT v), (Vmul v (FO (VF v)) x) = (VO v).
+Lemma Vmul_O_l : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vmul F v (FO F) x) = (VO F v).
 Proof.
-move=> v x.
-apply (Vadd_O_r_uniq v (Vmul v (FO (VF v)) x) (Vmul v (FO (VF v)) x)).
-rewrite - (Vmul_add_distr_r v (FO (VF v)) (FO (VF v)) x).
-rewrite (Fadd_O_l (VF v) (FO (VF v))).
+move=> F v x.
+apply (Vadd_O_r_uniq F v (Vmul F v (FO F) x) (Vmul F v (FO F) x)).
+rewrite - (Vmul_add_distr_r F v (FO F) (FO F) x).
+rewrite (Fadd_O_l F (FO F)).
 by [].
 Qed.
 
-Lemma Vmul_eq_compat_l : forall (v : VectorSpace) (x : FT (VF v)) (y z : VT v), y = z -> (Vmul v x y) = (Vmul v x z).
+Lemma Vmul_eq_compat_l : forall (F : Field) (v : VectorSpace F) (x : FT F) (y z : VT F v), y = z -> (Vmul F v x y) = (Vmul F v x z).
 Proof.
-move=> v x y z H1.
+move=> F v x y z H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_eq_compat_r : forall (v : VectorSpace) (x : VT v) (y z : FT (VF v)), y = z -> (Vmul v y x) = (Vmul v z x).
+Lemma Vmul_eq_compat_r : forall (F : Field) (v : VectorSpace F) (x : VT F v) (y z : FT F), y = z -> (Vmul F v y x) = (Vmul F v z x).
 Proof.
-move=> v x y z H1.
+move=> F v x y z H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_eq_reg_l : forall (v : VectorSpace) (x : FT (VF v)) (y z : VT v), (Vmul v x y) = (Vmul v x z) -> x <> (FO (VF v)) -> y = z.
+Lemma Vmul_eq_reg_l : forall (F : Field) (v : VectorSpace F) (x : FT F) (y z : VT F v), (Vmul F v x y) = (Vmul F v x z) -> x <> (FO F) -> y = z.
 Proof.
-move=> v x y z H1 H2.
-rewrite - (Vmul_I_l v y).
-rewrite - (Vmul_I_l v z).
-rewrite - (Finv_l (VF v) x H2).
-rewrite - (Vmul_assoc v (Finv (VF v) x) x y).
-rewrite - (Vmul_assoc v (Finv (VF v) x) x z).
+move=> F v x y z H1 H2.
+rewrite - (Vmul_I_l F v y).
+rewrite - (Vmul_I_l F v z).
+rewrite - (Finv_l F x H2).
+rewrite - (Vmul_assoc F v (Finv F x) x y).
+rewrite - (Vmul_assoc F v (Finv F x) x z).
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vmul_eq_reg_r : forall (v : VectorSpace) (x : VT v) (y z : FT (VF v)), (Vmul v y x) = (Vmul v z x) -> x <> (VO v) -> y = z.
+Lemma Vmul_eq_reg_r : forall (F : Field) (v : VectorSpace F) (x : VT F v) (y z : FT F), (Vmul F v y x) = (Vmul F v z x) -> x <> (VO F v) -> y = z.
 Proof.
-move=> v x y z H1 H2.
+move=> F v x y z H1 H2.
 apply NNPP.
 move=> H3.
 apply H2.
-rewrite - (Vmul_I_l v x).
-rewrite - (Finv_l (VF v) (Fadd (VF v) y (Fopp (VF v) z))).
-rewrite - (Vmul_assoc v (Finv (VF v) (Fadd (VF v) y (Fopp (VF v) z))) (Fadd (VF v) y (Fopp (VF v) z)) x).
-suff: ((Vmul v (Fadd (VF v) y (Fopp (VF v) z)) x) = VO v).
+rewrite - (Vmul_I_l F v x).
+rewrite - (Finv_l F (Fadd F y (Fopp F z))).
+rewrite - (Vmul_assoc F v (Finv F (Fadd F y (Fopp F z))) (Fadd F y (Fopp F z)) x).
+suff: ((Vmul F v (Fadd F y (Fopp F z)) x) = VO F v).
 move=> H4.
 rewrite H4.
-apply (Vmul_O_r v (Finv (VF v) (Fadd (VF v) y (Fopp (VF v) z)))).
-apply (Vadd_eq_reg_r v (Vmul v z x) (Vmul v (Fadd (VF v) y (Fopp (VF v) z)) x) (VO v)).
-rewrite (Vadd_O_l v (Vmul v z x)).
-rewrite (Vmul_add_distr_r v y (Fopp (VF v) z) x).
-rewrite (Vadd_assoc v (Vmul v y x) (Vmul v (Fopp (VF v) z) x) (Vmul v z x)).
-rewrite - (Vmul_add_distr_r v (Fopp (VF v) z) z x).
-rewrite (Fadd_opp_l (VF v) z).
-rewrite (Vmul_O_l v x).
+apply (Vmul_O_r F v (Finv F (Fadd F y (Fopp F z)))).
+apply (Vadd_eq_reg_r F v (Vmul F v z x) (Vmul F v (Fadd F y (Fopp F z)) x) (VO F v)).
+rewrite (Vadd_O_l F v (Vmul F v z x)).
+rewrite (Vmul_add_distr_r F v y (Fopp F z) x).
+rewrite (Vadd_assoc F v (Vmul F v y x) (Vmul F v (Fopp F z) x) (Vmul F v z x)).
+rewrite - (Vmul_add_distr_r F v (Fopp F z) z x).
+rewrite (Fadd_opp_l F z).
+rewrite (Vmul_O_l F v x).
 rewrite H1.
-apply (Vadd_O_r v (Vmul v z x)).
+apply (Vadd_O_r F v (Vmul F v z x)).
 move=> H4.
 apply H3.
-apply (Fminus_diag_uniq (VF v) y z H4).
+apply (Fminus_diag_uniq F y z H4).
 Qed.
 
-Lemma Vmul_integral : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v x y) = (VO v) -> x = (FO (VF v)) \/ y = (VO v).
+Lemma Vmul_integral : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vmul F v x y) = (VO F v) -> x = (FO F) \/ y = (VO F v).
 Proof.
-move=> v x y H1.
-apply (NNPP (x = FO (VF v) \/ y = VO v)).
+move=> F v x y H1.
+apply (NNPP (x = FO F \/ y = VO F v)).
 move=> H2.
 apply H2.
 right.
-apply (Vmul_eq_reg_l v x y (VO v)).
+apply (Vmul_eq_reg_l F v x y (VO F v)).
 rewrite H1.
-rewrite (Vmul_O_r v x).
+rewrite (Vmul_O_r F v x).
 by [].
 move=> H3.
 apply H2.
@@ -199,262 +198,261 @@ left.
 apply H3.
 Qed.
 
-Lemma Vmul_eq_O_compat : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (x = (FO (VF v)) \/ y = (VO v)) -> (Vmul v x y) = (VO v).
+Lemma Vmul_eq_O_compat : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (x = (FO F) \/ y = (VO F v)) -> (Vmul F v x y) = (VO F v).
 Proof.
-move=> v x y H1.
+move=> F v x y H1.
 case H1.
 move=> H2.
 rewrite H2.
-apply (Vmul_O_l v y).
+apply (Vmul_O_l F v y).
 move=> H2.
 rewrite H2.
-apply (Vmul_O_r v x).
+apply (Vmul_O_r F v x).
 Qed.
 
-Lemma Vmul_eq_O_compat_r : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), x = (FO (VF v)) -> (Vmul v x y) = (VO v).
+Lemma Vmul_eq_O_compat_r : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), x = (FO F) -> (Vmul F v x y) = (VO F v).
 Proof.
-move=> v x y H1.
+move=> F v x y H1.
 rewrite H1.
-apply (Vmul_O_l v y).
+apply (Vmul_O_l F v y).
 Qed.
 
-Lemma Vmul_eq_O_compat_l : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), y = (VO v) -> (Vmul v x y) = (VO v).
+Lemma Vmul_eq_O_compat_l : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), y = (VO F v) -> (Vmul F v x y) = (VO F v).
 Proof.
-move=> v x y H1.
+move=> F v x y H1.
 rewrite H1.
-apply (Vmul_O_r v x).
+apply (Vmul_O_r F v x).
 Qed.
 
-Lemma Vmul_neq_O_reg : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v x y) <> (VO v) -> x <> (FO (VF v)) /\ y <> (VO v).
+Lemma Vmul_neq_O_reg : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vmul F v x y) <> (VO F v) -> x <> (FO F) /\ y <> (VO F v).
 Proof.
-move=> v x y H1.
+move=> F v x y H1.
 apply conj.
 move=> H2.
 apply H1.
 rewrite H2.
-apply (Vmul_O_l v y).
+apply (Vmul_O_l F v y).
 move=> H2.
 apply H1.
 rewrite H2.
-apply (Vmul_O_r v x).
+apply (Vmul_O_r F v x).
 Qed.
 
-Lemma Vmul_integral_contrapositive : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), x <> (FO (VF v)) /\ y <> (VO v) -> (Vmul v x y) <> (VO v).
+Lemma Vmul_integral_contrapositive : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), x <> (FO F) /\ y <> (VO F v) -> (Vmul F v x y) <> (VO F v).
 Proof.
-move=> v x y H1 H2.
+move=> F v x y H1 H2.
 apply (proj1 H1).
-apply (Vmul_eq_reg_r v y x (FO (VF v))).
-rewrite (Vmul_O_l v y).
+apply (Vmul_eq_reg_r F v y x (FO F)).
+rewrite (Vmul_O_l F v y).
 apply H2.
 apply (proj2 H1).
 Qed.
 
-Lemma Vmul_integral_contrapositive_currified : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), x <> (FO (VF v)) -> y <> (VO v) -> (Vmul v x y) <> (VO v).
+Lemma Vmul_integral_contrapositive_currified : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), x <> (FO F) -> y <> (VO F v) -> (Vmul F v x y) <> (VO F v).
 Proof.
-move=> v x y H1 H2 H3.
+move=> F v x y H1 H2 H3.
 apply H1.
-apply (Vmul_eq_reg_r v y x (FO (VF v))).
-rewrite (Vmul_O_l v y).
+apply (Vmul_eq_reg_r F v y x (FO F)).
+rewrite (Vmul_O_l F v y).
 apply H3.
 apply H2.
 Qed.
 
-Lemma Vopp_eq_compat : forall (v : VectorSpace) (x y : VT v), x = y -> (Vopp v x) = (Vopp v y).
+Lemma Vopp_eq_compat : forall (F : Field) (v : VectorSpace F) (x y : VT F v), x = y -> (Vopp F v x) = (Vopp F v y).
 Proof.
-move=> v x y H1.
+move=> F v x y H1.
 rewrite H1.
 by [].
 Qed.
 
-Lemma Vopp_O : forall (v : VectorSpace), (Vopp v (VO v)) = (VO v).
+Lemma Vopp_O : forall (F : Field) (v : VectorSpace F), (Vopp F v (VO F v)) = (VO F v).
 Proof.
-move=> v.
-apply (Vadd_O_r_uniq v (VO v) (Vopp v (VO v))).
-apply (Vadd_opp_r v (VO v)).
+move=> F v.
+apply (Vadd_O_r_uniq F v (VO F v) (Vopp F v (VO F v))).
+apply (Vadd_opp_r F v (VO F v)).
 Qed.
 
-Lemma Vopp_eq_O_compat : forall (v : VectorSpace) (x : VT v), x = (VO v) -> (Vopp v x) = (VO v).
+Lemma Vopp_eq_O_compat : forall (F : Field) (v : VectorSpace F) (x : VT F v), x = (VO F v) -> (Vopp F v x) = (VO F v).
 Proof.
-move=> v x H1.
+move=> F v x H1.
 rewrite H1.
-apply (Vopp_O v).
+apply (Vopp_O F v).
 Qed.
 
-Lemma Vopp_involutive : forall (v : VectorSpace) (x : VT v), (Vopp v (Vopp v x)) = x.
+Lemma Vopp_involutive : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vopp F v (Vopp F v x)) = x.
 Proof.
-move=> v x.
-suff: x = Vopp v (Vopp v x).
+move=> F v x.
+suff: x = Vopp F v (Vopp F v x).
 move=> H1.
 rewrite{2} H1.
 by [].
-apply (Vadd_opp_r_uniq v (Vopp v x)).
-apply (Vadd_opp_l v x).
+apply (Vadd_opp_r_uniq F v (Vopp F v x)).
+apply (Vadd_opp_l F v x).
 Qed.
 
-Lemma Vopp_neq_O_compat : forall (v : VectorSpace) (x : VT v), x <> (VO v) -> (Vopp v x) <> (VO v).
+Lemma Vopp_neq_O_compat : forall (F : Field) (v : VectorSpace F) (x : VT F v), x <> (VO F v) -> (Vopp F v x) <> (VO F v).
 Proof.
-move=> v x H1.
-move=> H2.
+move=> F v x H1 H2.
 apply H1.
-rewrite - (Vopp_involutive v x).
-apply (Vopp_eq_O_compat v (Vopp v x) H2).
+rewrite - (Vopp_involutive F v x).
+apply (Vopp_eq_O_compat F v (Vopp F v x) H2).
 Qed.
 
-Lemma Vopp_add_distr : forall (v : VectorSpace) (x y : VT v), (Vopp v (Vadd v x y)) = (Vadd v (Vopp v x) (Vopp v y)).
+Lemma Vopp_add_distr : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vopp F v (Vadd F v x y)) = (Vadd F v (Vopp F v x) (Vopp F v y)).
 Proof.
-move=> v x y.
-suff: Vadd v (Vopp v x) (Vopp v y) = Vopp v (Vadd v x y).
+move=> F v x y.
+suff: Vadd F v (Vopp F v x) (Vopp F v y) = Vopp F v (Vadd F v x y).
 move=> H1.
 rewrite H1.
 by [].
-apply (Vadd_opp_r_uniq v (Vadd v x y)).
-rewrite (Vadd_comm v x y).
-rewrite - (Vadd_assoc v (Vadd v y x) (Vopp v x) (Vopp v y)).
-rewrite (Vadd_assoc v y x (Vopp v x)).
-rewrite (Vadd_opp_r v x).
-rewrite (Vadd_O_r v y).
-apply (Vadd_opp_r v y).
+apply (Vadd_opp_r_uniq F v (Vadd F v x y)).
+rewrite (Vadd_comm F v x y).
+rewrite - (Vadd_assoc F v (Vadd F v y x) (Vopp F v x) (Vopp F v y)).
+rewrite (Vadd_assoc F v y x (Vopp F v x)).
+rewrite (Vadd_opp_r F v x).
+rewrite (Vadd_O_r F v y).
+apply (Vadd_opp_r F v y).
 Qed.
 
-Lemma Vopp_mul_distr_l : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vopp v (Vmul v x y)) = (Vmul v (Fopp (VF v) x) y).
+Lemma Vopp_mul_distr_l : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vopp F v (Vmul F v x y)) = (Vmul F v (Fopp F x) y).
 Proof.
-move=> v x y.
-suff: Vmul v (Fopp (VF v) x) y = Vopp v (Vmul v x y).
+move=> F v x y.
+suff: Vmul F v (Fopp F x) y = Vopp F v (Vmul F v x y).
 move=> H1.
 rewrite H1.
 by [].
-apply (Vadd_opp_r_uniq v (Vmul v x y)).
-rewrite - (Vmul_add_distr_r v x (Fopp (VF v) x) y).
-rewrite (Fadd_opp_r (VF v) x).
-apply (Vmul_O_l v y).
+apply (Vadd_opp_r_uniq F v (Vmul F v x y)).
+rewrite - (Vmul_add_distr_r F v x (Fopp F x) y).
+rewrite (Fadd_opp_r F x).
+apply (Vmul_O_l F v y).
 Qed.
 
-Lemma Vopp_mul_distr_l_reverse : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v (Fopp (VF v) x) y) = (Vopp v (Vmul v x y)).
+Lemma Vopp_mul_distr_l_reverse : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vmul F v (Fopp F x) y) = (Vopp F v (Vmul F v x y)).
 Proof.
-move=> v x y.
-rewrite (Vopp_mul_distr_l v x y).
+move=> F v x y.
+rewrite (Vopp_mul_distr_l F v x y).
 reflexivity.
 Qed.
 
-Lemma Vopp_mul_distr_r : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vopp v (Vmul v x y)) = (Vmul v x (Vopp v y)).
+Lemma Vopp_mul_distr_r : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vopp F v (Vmul F v x y)) = (Vmul F v x (Vopp F v y)).
 Proof.
-move=> v x y.
-suff: Vmul v x (Vopp v y) = Vopp v (Vmul v x y).
+move=> F v x y.
+suff: Vmul F v x (Vopp F v y) = Vopp F v (Vmul F v x y).
 move=> H1.
 rewrite H1.
 by [].
-apply (Vadd_opp_r_uniq v (Vmul v x y)).
-rewrite - (Vmul_add_distr_l v x y (Vopp v y)).
-rewrite (Vadd_opp_r v y).
-apply (Vmul_O_r v x).
+apply (Vadd_opp_r_uniq F v (Vmul F v x y)).
+rewrite - (Vmul_add_distr_l F v x y (Vopp F v y)).
+rewrite (Vadd_opp_r F v y).
+apply (Vmul_O_r F v x).
 Qed.
 
-Lemma Vopp_mul_distr_r_reverse : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v x (Vopp v y)) = (Vopp v (Vmul v x y)).
+Lemma Vopp_mul_distr_r_reverse : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vmul F v x (Vopp F v y)) = (Vopp F v (Vmul F v x y)).
 Proof.
-move=> v x y.
-rewrite (Vopp_mul_distr_r v x y).
+move=> F v x y.
+rewrite (Vopp_mul_distr_r F v x y).
 reflexivity.
 Qed.
 
-Lemma Vmul_opp_opp : forall (v : VectorSpace) (x : FT (VF v)) (y : VT v), (Vmul v (Fopp (VF v) x) (Vopp v y)) = (Vmul v x y).
+Lemma Vmul_opp_opp : forall (F : Field) (v : VectorSpace F) (x : FT F) (y : VT F v), (Vmul F v (Fopp F x) (Vopp F v y)) = (Vmul F v x y).
 Proof.
-move=> v x y.
-rewrite (Vopp_mul_distr_l_reverse v x (Vopp v y)).
-rewrite (Vopp_mul_distr_r_reverse v x y).
-apply (Vopp_involutive v (Vmul v x y)).
+move=> F v x y.
+rewrite (Vopp_mul_distr_l_reverse F v x (Vopp F v y)).
+rewrite (Vopp_mul_distr_r_reverse F v x y).
+apply (Vopp_involutive F v (Vmul F v x y)).
 Qed.
 
-Lemma Vminus_O_r : forall (v : VectorSpace) (x : VT v), (Vadd v x (Vopp v (VO v))) = x.
+Lemma Vminus_O_r : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vadd F v x (Vopp F v (VO F v))) = x.
 Proof.
-move=> v x.
-rewrite (Vopp_O v).
-apply (Vadd_O_r v x).
+move=> F v x.
+rewrite (Vopp_O F v).
+apply (Vadd_O_r F v x).
 Qed.
 
-Lemma Vminus_O_l : forall (v : VectorSpace) (x : VT v), (Vadd v (VO v) (Vopp v x)) = (Vopp v x).
+Lemma Vminus_O_l : forall (F : Field) (v : VectorSpace F) (x : VT F v), (Vadd F v (VO F v) (Vopp F v x)) = (Vopp F v x).
 Proof.
-move=> v x.
-apply (Vadd_O_l v (Vopp v x)).
+move=> F v x.
+apply (Vadd_O_l F v (Vopp F v x)).
 Qed.
 
-Lemma Vopp_minus_distr : forall (v : VectorSpace) (x y : VT v), (Vopp v (Vadd v x (Vopp v y))) = (Vadd v y (Vopp v x)).
+Lemma Vopp_minus_distr : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vopp F v (Vadd F v x (Vopp F v y))) = (Vadd F v y (Vopp F v x)).
 Proof.
-move=> v x y.
-rewrite (Vopp_add_distr v x (Vopp v y)).
-rewrite (Vopp_involutive v y).
-apply (Vadd_comm v (Vopp v x) y).
+move=> F v x y.
+rewrite (Vopp_add_distr F v x (Vopp F v y)).
+rewrite (Vopp_involutive F v y).
+apply (Vadd_comm F v (Vopp F v x) y).
 Qed.
 
-Lemma Vopp_minus_distr' : forall (v : VectorSpace) (x y : VT v), (Vopp v (Vadd v y (Vopp v x))) = (Vadd v x (Vopp v y)).
+Lemma Vopp_minus_distr' : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vopp F v (Vadd F v y (Vopp F v x))) = (Vadd F v x (Vopp F v y)).
 Proof.
-move=> v x y.
-rewrite (Vopp_add_distr v y (Vopp v x)).
-rewrite (Vopp_involutive v x).
-apply (Vadd_comm v (Vopp v y) x).
+move=> F v x y.
+rewrite (Vopp_add_distr F v y (Vopp F v x)).
+rewrite (Vopp_involutive F v x).
+apply (Vadd_comm F v (Vopp F v y) x).
 Qed.
 
-Lemma Vminus_diag_eq : forall (v : VectorSpace) (x y : VT v), x = y -> (Vadd v x (Vopp v y)) = (VO v).
+Lemma Vminus_diag_eq : forall (F : Field) (v : VectorSpace F) (x y : VT F v), x = y -> (Vadd F v x (Vopp F v y)) = (VO F v).
 Proof.
-move=> v x y H1.
+move=> F v x y H1.
 rewrite H1.
-apply (Vadd_opp_r v y).
+apply (Vadd_opp_r F v y).
 Qed.
 
-Lemma Vminus_diag_uniq : forall (v : VectorSpace) (x y : VT v), (Vadd v x (Vopp v y)) = (VO v) -> x = y.
+Lemma Vminus_diag_uniq : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v x (Vopp F v y)) = (VO F v) -> x = y.
 Proof.
-move=> v x y H1.
-rewrite<- (Vadd_O_r v x).
-rewrite<- (Vadd_opp_l v y).
-rewrite<- (Vadd_O_l v y) at 3.
-rewrite<- (Vadd_assoc v x (Vopp v y) y).
+move=> F v x y H1.
+rewrite<- (Vadd_O_r F v x).
+rewrite<- (Vadd_opp_l F v y).
+rewrite<- (Vadd_O_l F v y) at 3.
+rewrite<- (Vadd_assoc F v x (Vopp F v y) y).
 rewrite H1.
 reflexivity.
 Qed.
 
-Lemma Vminus_diag_uniq_sym : forall (v : VectorSpace) (x y : VT v), (Vadd v y (Vopp v x)) = (VO v) -> x = y.
+Lemma Vminus_diag_uniq_sym : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v y (Vopp F v x)) = (VO F v) -> x = y.
 Proof.
-move=> v x y H1.
-rewrite (Vminus_diag_uniq v y x H1).
+move=> F v x y H1.
+rewrite (Vminus_diag_uniq F v y x H1).
 reflexivity.
 Qed.
 
-Lemma Vadd_minus : forall (v : VectorSpace) (x y : VT v), (Vadd v x (Vadd v y (Vopp v x))) = y.
+Lemma Vadd_minus : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v x (Vadd F v y (Vopp F v x))) = y.
 Proof.
-move=> v x y.
-rewrite (Vadd_comm v y (Vopp v x)).
-rewrite<- (Vadd_assoc v x (Vopp v x) y).
-rewrite (Vadd_opp_r v x).
-apply (Vadd_O_l v y).
+move=> F v x y.
+rewrite (Vadd_comm F v y (Vopp F v x)).
+rewrite<- (Vadd_assoc F v x (Vopp F v x) y).
+rewrite (Vadd_opp_r F v x).
+apply (Vadd_O_l F v y).
 Qed.
 
-Lemma Vminus_eq_contra : forall (v : VectorSpace) (x y : VT v), x <> y -> (Vadd v x (Vopp v y)) <> (VO v).
+Lemma Vminus_eq_contra : forall (F : Field) (v : VectorSpace F) (x y : VT F v), x <> y -> (Vadd F v x (Vopp F v y)) <> (VO F v).
 Proof.
-move=> v x y H1 H2.
+move=> F v x y H1 H2.
 apply H1.
-apply (Vminus_diag_uniq v x y H2).
+apply (Vminus_diag_uniq F v x y H2).
 Qed.
 
-Lemma Vminus_not_eq : forall (v : VectorSpace) (x y : VT v), (Vadd v x (Vopp v y)) <> (VO v) -> x <> y.
+Lemma Vminus_not_eq : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v x (Vopp F v y)) <> (VO F v) -> x <> y.
 Proof.
-move=> v x y H1 H2.
+move=> F v x y H1 H2.
 apply H1.
-apply (Vminus_diag_eq v x y H2).
+apply (Vminus_diag_eq F v x y H2).
 Qed.
 
-Lemma Vminus_not_eq_right : forall (v : VectorSpace) (x y : VT v), (Vadd v y (Vopp v x)) <> (VO v) -> x <> y.
+Lemma Vminus_not_eq_right : forall (F : Field) (v : VectorSpace F) (x y : VT F v), (Vadd F v y (Vopp F v x)) <> (VO F v) -> x <> y.
 Proof.
-move=> v x y H1 H2.
+move=> F v x y H1 H2.
 apply H1.
-apply (Vminus_diag_eq v y x).
+apply (Vminus_diag_eq F v y x).
 rewrite H2.
 reflexivity.
 Qed.
 
-Lemma Vmul_minus_distr_l : forall (v : VectorSpace) (x : FT (VF v)) (y z : VT v), (Vmul v x (Vadd v y (Vopp v z))) = (Vadd v (Vmul v x y) (Vopp v (Vmul v x z))).
+Lemma Vmul_minus_distr_l : forall (F : Field) (v : VectorSpace F) (x : FT F) (y z : VT F v), (Vmul F v x (Vadd F v y (Vopp F v z))) = (Vadd F v (Vmul F v x y) (Vopp F v (Vmul F v x z))).
 Proof.
-move=> v x y z.
-rewrite (Vmul_add_distr_l v x y (Vopp v z)).
-rewrite (Vopp_mul_distr_r v x z).
+move=> F v x y z.
+rewrite (Vmul_add_distr_l F v x y (Vopp F v z)).
+rewrite (Vopp_mul_distr_r F v x z).
 reflexivity.
 Qed.
 


### PR DESCRIPTION
## 概要
今までベクトル空間の構造の中に体を持たせていた。体Fそれぞれに対しFベクトル空間を定義するようにした。
## 背景
今までの定義だと、体が共通のベクトル空間をまとめて1つの型にするのを自然にできなかった。