### PR TITLE
ベクトル空間の同型写像の定義を変更

### DIFF
--- a/MyAlgebraicStructure/MyVectorSpace.v
+++ b/MyAlgebraicStructure/MyVectorSpace.v
@@ -457,7 +457,7 @@ rewrite (Vopp_mul_distr_r F v x z).
 reflexivity.
 Qed.
 
-Definition IsomorphicVS (F : Field) (v1 v2 : VectorSpace F) (f : VT F v1 -> VT F v2) := Bijective f /\ f (VO F v1) = VO F v2 /\ (forall (x y : VT F v1), f (Vadd F v1 x y) = Vadd F v2 (f x) (f y)) /\ (forall (c : FT F) (x : VT F v1), f (Vmul F v1 c x) = Vmul F v2 c (f x)).
+Definition IsomorphicVS (F : Field) (v1 v2 : VectorSpace F) (f : VT F v1 -> VT F v2) := Bijective f /\ (forall (x y : VT F v1), f (Vadd F v1 x y) = Vadd F v2 (f x) (f y)) /\ (forall (c : FT F) (x : VT F v1), f (Vmul F v1 c x) = Vmul F v2 c (f x)).
 
 Lemma IsomorphicChainVS : forall (F : Field) (v1 v2 v3 : VectorSpace F) (f : VT F v1 -> VT F v2) (g : VT F v2 -> VT F v3), IsomorphicVS F v1 v2 f -> IsomorphicVS F v2 v3 g -> IsomorphicVS F v1 v3 (fun (x : VT F v1) => g (f x)).
 Proof.
@@ -465,15 +465,12 @@ move=> F v1 v2 v3 f g H1 H2.
 apply conj.
 apply (BijChain (VT F v1) (VT F v2) (VT F v3) f g (proj1 H1) (proj1 H2)).
 apply conj.
-rewrite (proj1 (proj2 H1)).
-apply (proj1 (proj2 H2)).
-apply conj.
 move=> x y.
-rewrite (proj1 (proj2 (proj2 H1)) x y).
-apply (proj1 (proj2 (proj2 H2)) (f x) (f y)).
+rewrite ((proj1 (proj2 H1)) x y).
+apply ((proj1 (proj2 H2)) (f x) (f y)).
 move=> c x.
-rewrite (proj2 (proj2 (proj2 H1)) c x).
-apply (proj2 (proj2 (proj2 H2)) c (f x)).
+rewrite (proj2 (proj2 H1) c x).
+apply (proj2 (proj2 H2) c (f x)).
 Qed.
 
 Lemma IsomorphicInvVS : forall (F : Field) (v1 v2 : VectorSpace F) (f : VT F v1 -> VT F v2) (g : VT F v2 -> VT F v1), IsomorphicVS F v1 v2 f -> (forall (x : VT F v1), g (f x) = x) /\ (forall (y : VT F v2), f (g y) = y) -> IsomorphicVS F v2 v1 g.
@@ -485,22 +482,17 @@ apply conj.
 apply (proj2 H2).
 apply (proj1 H2).
 apply conj.
-rewrite - (proj1 (proj2 H1)).
-apply (proj1 H2).
-apply conj.
 move=> x y.
 apply (BijInj (VT F v1) (VT F v2) f (proj1 H1) (g (Vadd F v2 x y)) (Vadd F v1 (g x) (g y))).
-rewrite (proj1 (proj2 (proj2 H1)) (g x) (g y)).
-rewrite (proj2 H2 (Vadd F v2 x y)).
+rewrite (proj1 (proj2 H1) (g x) (g y)).
 rewrite (proj2 H2 x).
 rewrite (proj2 H2 y).
-reflexivity.
+apply (proj2 H2 (Vadd F v2 x y)).
 move=> c x.
 apply (BijInj (VT F v1) (VT F v2) f (proj1 H1) (g (Vmul F v2 c x)) (Vmul F v1 c (g x))).
-rewrite (proj2 (proj2 (proj2 H1)) c (g x)).
-rewrite (proj2 H2 (Vmul F v2 c x)).
+rewrite (proj2 (proj2 H1) c (g x)).
 rewrite (proj2 H2 x).
-reflexivity.
+apply (proj2 H2 (Vmul F v2 c x)).
 Qed.
 
 End VectorSpace.


### PR DESCRIPTION
## 概要
同型写像の条件の1つの
```
f (VO F v1) = VO F v2
```
を消した。
## 背景
```
f (Vmul F v1 c x) = Vmul F v2 c (f x))
```
 から導けるので不要なため消した。