### PR TITLE
行列ライブラリのリファクタリング

### DIFF
--- a/LinearAlgebra/Matrix.v
+++ b/LinearAlgebra/Matrix.v
@@ -5,7 +5,9 @@ Add LoadPath "BasicNotation" as BasicNotation.
 
 From mathcomp Require Import ssreflect.
 Require Import Coq.Sets.Ensembles.
-Require Export QArith_base.
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Arith.Plus.
+Require Import Coq.Arith.Minus.
 Require Import Classical.
 Require Import Coq.Sets.Finite_sets.
 Require Import Coq.Sets.Finite_sets_facts.
@@ -29,17 +31,17 @@ Definition FPCM (f : Field) := mkCommutativeMonoid (FT f) (FO f) (Fadd f) (Fadd_
 
 Definition FMCM (f : Field) := mkCommutativeMonoid (FT f) (FI f) (Fmul f) (Fmul_comm f) (Fmul_I_r f) (Fmul_assoc f).
 
-Definition Matrix (f : Field) (M N : nat) := {n : nat| (n < M)%nat } -> {n : nat| (n < N)%nat } -> (FT f).
+Definition Matrix (f : Field) (M N : nat) := {n : nat| (n < M) } -> {n : nat| (n < N) } -> (FT f).
 
-Definition Mplus (f : Field) (M N : nat) := fun (A B : Matrix f M N) (x : {n : nat| (n < M)%nat }) (y : {n : nat| (n < N)%nat }) => (Fadd f (A x y) (B x y)).
+Definition Mplus (f : Field) (M N : nat) := fun (A B : Matrix f M N) (x : {n : nat| (n < M) }) (y : {n : nat| (n < N) }) => (Fadd f (A x y) (B x y)).
 
-Definition Mmult (f : Field) (M N K : nat) := fun (A : Matrix f M N) (B : Matrix f N K) (x : {n : nat| (n < M)%nat }) (y : {n : nat| (n < K)%nat }) => MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat| (n < N) %nat}) (CountFinite N)) (FPCM f) (fun (n : Count N) => Fmul f (A x n) (B n y)).
+Definition Mmult (f : Field) (M N K : nat) := fun (A : Matrix f M N) (B : Matrix f N K) (x : {n : nat| (n < M) }) (y : {n : nat| (n < K) }) => MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat| (n < N) }) (CountFinite N)) (FPCM f) (fun (n : Count N) => Fmul f (A x n) (B n y)).
 
-Definition Mopp (f : Field) (M N : nat) := fun (A : Matrix f M N) (x : {n : nat| (n < M)%nat }) (y : {n : nat| (n < N)%nat }) => (Fopp f (A x y)).
+Definition Mopp (f : Field) (M N : nat) := fun (A : Matrix f M N) (x : {n : nat| (n < M) }) (y : {n : nat| (n < N) }) => (Fopp f (A x y)).
 
-Definition MO (f : Field) (M N : nat) := fun (x : {n : nat| (n < M)%nat }) (y : {n : nat| (n < N)%nat }) => (FO f).
+Definition MO (f : Field) (M N : nat) := fun (x : {n : nat| (n < M) }) (y : {n : nat| (n < N) }) => (FO f).
 
-Definition MI (f : Field) (N : nat) := fun (x : {n : nat| (n < N)%nat }) (y : {n : nat| (n < N)%nat }) => match (Nat.eq_dec (proj1_sig x) (proj1_sig y)) with
+Definition MI (f : Field) (N : nat) := fun (x : {n : nat| (n < N) }) (y : {n : nat| (n < N) }) => match (Nat.eq_dec (proj1_sig x) (proj1_sig y)) with
   | left _ => (FI f)
   | right _ => (FO f)
 end.
@@ -96,12 +98,12 @@ move=> x.
 apply functional_extensionality.
 move=> y.
 unfold Mmult.
-rewrite (MySumF2Excluded {n : nat | (n < N)%nat} (FPCM f) (fun n : Count N => Fmul f (A x n) (MI f N n y)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (fun (m : {n : nat | (n < N)%nat}) => proj1_sig m = proj1_sig y)).
-suff: (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (fun m : {n : nat | (n < N)%nat} => proj1_sig m = proj1_sig y)) = FiniteSingleton {n : nat | (n < N)%nat} y.
+rewrite (MySumF2Excluded {n : nat | (n < N)} (FPCM f) (fun n : Count N => Fmul f (A x n) (MI f N n y)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (fun (m : {n : nat | (n < N)}) => proj1_sig m = proj1_sig y)).
+suff: (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (fun m : {n : nat | (n < N)} => proj1_sig m = proj1_sig y)) = FiniteSingleton {n : nat | (n < N)} y.
 move=> H1.
 rewrite H1.
 rewrite MySumF2Singleton.
-suff: (MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (fun m : {n : nat | (n < N)%nat} => proj1_sig m = proj1_sig y))) (FPCM f) (fun n : Count N => Fmul f (A x n) (MI f N n y)) = FO f).
+suff: (MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (fun m : {n : nat | (n < N)} => proj1_sig m = proj1_sig y))) (FPCM f) (fun n : Count N => Fmul f (A x n) (MI f N n y)) = FO f).
 move=> H2.
 rewrite H2.
 simpl.
@@ -158,12 +160,12 @@ move=> x.
 apply functional_extensionality.
 move=> y.
 unfold Mmult.
-rewrite (MySumF2Excluded {n : nat | (n < M)%nat} (FPCM f) (fun n : Count M => Fmul f (MI f M x n) (A n y)) (exist (Finite (Count M)) (Full_set {n : nat | (n < M)%nat}) (CountFinite M)) (fun (m : {n : nat | (n < M)%nat}) => proj1_sig m = proj1_sig x)).
-suff: (FiniteIntersection {n : nat | (n < M)%nat} (exist (Finite (Count M)) (Full_set {n : nat | (n < M)%nat}) (CountFinite M)) (fun m : {n : nat | (n < M)%nat} => proj1_sig m = proj1_sig x)) = FiniteSingleton {n : nat | (n < M)%nat} x.
+rewrite (MySumF2Excluded {n : nat | (n < M)} (FPCM f) (fun n : Count M => Fmul f (MI f M x n) (A n y)) (exist (Finite (Count M)) (Full_set {n : nat | (n < M)}) (CountFinite M)) (fun (m : {n : nat | (n < M)}) => proj1_sig m = proj1_sig x)).
+suff: (FiniteIntersection {n : nat | (n < M)} (exist (Finite (Count M)) (Full_set {n : nat | (n < M)}) (CountFinite M)) (fun m : {n : nat | (n < M)} => proj1_sig m = proj1_sig x)) = FiniteSingleton {n : nat | (n < M)} x.
 move=> H1.
 rewrite H1.
 rewrite MySumF2Singleton.
-suff: (MySumF2 {n : nat | (n < M)%nat} (FiniteIntersection {n : nat | (n < M)%nat} (exist (Finite (Count M)) (Full_set {n : nat | (n < M)%nat}) (CountFinite M)) (Complement {n : nat | (n < M)%nat} (fun m : {n : nat | (n < M)%nat} => proj1_sig m = proj1_sig x))) (FPCM f) (fun n : Count M => Fmul f (MI f M x n) (A n y)) = FO f).
+suff: (MySumF2 {n : nat | (n < M)} (FiniteIntersection {n : nat | (n < M)} (exist (Finite (Count M)) (Full_set {n : nat | (n < M)}) (CountFinite M)) (Complement {n : nat | (n < M)} (fun m : {n : nat | (n < M)} => proj1_sig m = proj1_sig x))) (FPCM f) (fun n : Count M => Fmul f (MI f M x n) (A n y)) = FO f).
 move=> H2.
 rewrite H2.
 simpl.
@@ -221,22 +223,22 @@ apply functional_extensionality.
 move=> x.
 apply functional_extensionality.
 move=> y.
-suff: (Mmult f M K L (Mmult f M N K A B) C x y = MySumF2 ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat}) (FinitePair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K))) (FPCM f) (fun (nm : ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat})) => Fmul f (Fmul f (A x (fst nm)) (B (fst nm) (snd nm))) (C (snd nm) y))).
+suff: (Mmult f M K L (Mmult f M N K A B) C x y = MySumF2 ({n : nat | (n < N)} * {n : nat | (n < K)}) (FinitePair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K))) (FPCM f) (fun (nm : ({n : nat | (n < N)} * {n : nat | (n < K)})) => Fmul f (Fmul f (A x (fst nm)) (B (fst nm) (snd nm))) (C (snd nm) y))).
 move=> H1.
 rewrite H1.
-suff: (Mmult f M N L A (Mmult f N K L B C) x y = MySumF2 ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat}) (FinitePair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K))) (FPCM f) (fun (nm : ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat})) => Fmul f (Fmul f (A x (fst nm)) (B (fst nm) (snd nm))) (C (snd nm) y))).
+suff: (Mmult f M N L A (Mmult f N K L B C) x y = MySumF2 ({n : nat | (n < N)} * {n : nat | (n < K)}) (FinitePair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K))) (FPCM f) (fun (nm : ({n : nat | (n < N)} * {n : nat | (n < K)})) => Fmul f (Fmul f (A x (fst nm)) (B (fst nm) (snd nm))) (C (snd nm) y))).
 move=> H2.
 rewrite H2.
 reflexivity.
-rewrite (MySumF2Pair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (FPCM f) (fun (n0 : {n : nat | (n < N)%nat}) (k0 : {n : nat | (n < K)%nat}) => Fmul f (Fmul f (A x n0) (B n0 k0)) (C k0 y))).
+rewrite (MySumF2Pair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (FPCM f) (fun (n0 : {n : nat | (n < N)}) (k0 : {n : nat | (n < K)}) => Fmul f (Fmul f (A x n0) (B n0 k0)) (C k0 y))).
 unfold Mmult.
-suff: ((fun n : Count N => Fmul f (A x n) (MySumF2 {n0 : nat | (n0 < K)%nat} (exist (Finite (Count K)) (Full_set {n0 : nat | (n0 < K)%nat}) (CountFinite K)) (FPCM f) (fun n0 : Count K => Fmul f (B n n0) (C n0 y)))) = (fun u : {n : nat | (n < N)%nat} => MySumF2 {n : nat | (n < K)%nat} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (FPCM f) (fun k0 : {n : nat | (n < K)%nat} => Fmul f (Fmul f (A x u) (B u k0)) (C k0 y)))).
+suff: ((fun n : Count N => Fmul f (A x n) (MySumF2 {n0 : nat | (n0 < K)} (exist (Finite (Count K)) (Full_set {n0 : nat | (n0 < K)}) (CountFinite K)) (FPCM f) (fun n0 : Count K => Fmul f (B n n0) (C n0 y)))) = (fun u : {n : nat | (n < N)} => MySumF2 {n : nat | (n < K)} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (FPCM f) (fun k0 : {n : nat | (n < K)} => Fmul f (Fmul f (A x u) (B u k0)) (C k0 y)))).
 move=> H2.
 rewrite H2.
 reflexivity.
 apply functional_extensionality.
 move=> k.
-apply (FiniteSetInduction (Count K) (exist (Finite (Count K)) (Full_set {n0 : nat | (n0 < K)%nat}) (CountFinite K))).
+apply (FiniteSetInduction (Count K) (exist (Finite (Count K)) (Full_set {n0 : nat | (n0 < K)}) (CountFinite K))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -250,18 +252,18 @@ rewrite (Fmul_assoc f (A x k) (B k a1) (C a1 y)).
 reflexivity.
 apply H4.
 apply H4.
-suff: (MySumF2 ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat}) (FinitePair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K))) (FPCM f) (fun nm : {n : nat | (n < N)%nat} * {n : nat | (n < K)%nat} => Fmul f (Fmul f (A x (fst nm)) (B (fst nm) (snd nm))) (C (snd nm) y)) = MySumF2 ({n : nat | (n < K)%nat} * {n : nat | (n < N)%nat}) (FinitePair {n : nat | (n < K)%nat} {n : nat | (n < N)%nat} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))) (FPCM f) (fun nm : {n : nat | (n < K)%nat} * {n : nat | (n < N)%nat} => Fmul f (Fmul f (A x (snd nm)) (B (snd nm) (fst nm))) (C (fst nm) y))).
+suff: (MySumF2 ({n : nat | (n < N)} * {n : nat | (n < K)}) (FinitePair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K))) (FPCM f) (fun nm : {n : nat | (n < N)} * {n : nat | (n < K)} => Fmul f (Fmul f (A x (fst nm)) (B (fst nm) (snd nm))) (C (snd nm) y)) = MySumF2 ({n : nat | (n < K)} * {n : nat | (n < N)}) (FinitePair {n : nat | (n < K)} {n : nat | (n < N)} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))) (FPCM f) (fun nm : {n : nat | (n < K)} * {n : nat | (n < N)} => Fmul f (Fmul f (A x (snd nm)) (B (snd nm) (fst nm))) (C (fst nm) y))).
 move=> H2.
 rewrite H2.
 unfold Mmult.
-rewrite (MySumF2Pair {n : nat | (n < K)%nat} {n : nat | (n < N)%nat} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FPCM f) (fun (n0 : {n : nat | (n < K)%nat}) (k0 : {n : nat | (n < N)%nat}) => Fmul f (Fmul f (A x k0) (B k0 n0)) (C n0 y))).
-suff: ((fun n : Count K => Fmul f (MySumF2 {n0 : nat | (n0 < N)%nat} (exist (Finite (Count N)) (Full_set {n0 : nat | (n0 < N)%nat}) (CountFinite N)) (FPCM f) (fun n0 : Count N => Fmul f (A x n0) (B n0 n))) (C n y)) = (fun u : {n : nat | (n < K)%nat} => MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FPCM f) (fun k0 : {n : nat | (n < N)%nat} => Fmul f (Fmul f (A x k0) (B k0 u)) (C u y)))).
+rewrite (MySumF2Pair {n : nat | (n < K)} {n : nat | (n < N)} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FPCM f) (fun (n0 : {n : nat | (n < K)}) (k0 : {n : nat | (n < N)}) => Fmul f (Fmul f (A x k0) (B k0 n0)) (C n0 y))).
+suff: ((fun n : Count K => Fmul f (MySumF2 {n0 : nat | (n0 < N)} (exist (Finite (Count N)) (Full_set {n0 : nat | (n0 < N)}) (CountFinite N)) (FPCM f) (fun n0 : Count N => Fmul f (A x n0) (B n0 n))) (C n y)) = (fun u : {n : nat | (n < K)} => MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FPCM f) (fun k0 : {n : nat | (n < N)} => Fmul f (Fmul f (A x k0) (B k0 u)) (C u y)))).
 move=> H3.
 rewrite H3.
 reflexivity.
 apply functional_extensionality.
 move=> k.
-apply (FiniteSetInduction (Count N) (exist (Finite (Count N)) (Full_set {n0 : nat | (n0 < N)%nat}) (CountFinite N))).
+apply (FiniteSetInduction (Count N) (exist (Finite (Count N)) (Full_set {n0 : nat | (n0 < N)}) (CountFinite N))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -274,14 +276,14 @@ rewrite H6.
 reflexivity.
 apply H5.
 apply H5.
-suff: (forall u : ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat}), proj1_sig (FinitePair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K))) u -> proj1_sig (FinitePair {n : nat | (n < K)%nat} {n : nat | (n < N)%nat} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))) ((fun nm : {n : nat | (n < N)%nat} * {n : nat | (n < K)%nat} => (snd nm, fst nm)) u)).
+suff: (forall u : ({n : nat | (n < N)} * {n : nat | (n < K)}), proj1_sig (FinitePair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K))) u -> proj1_sig (FinitePair {n : nat | (n < K)} {n : nat | (n < N)} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))) ((fun nm : {n : nat | (n < N)} * {n : nat | (n < K)} => (snd nm, fst nm)) u)).
 move=> H1.
-rewrite - (MySumF2BijectiveSame ({n : nat | (n < N)%nat} * {n : nat | (n < K)%nat}) (FinitePair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K))) ({n : nat | (n < K)%nat} * {n : nat | (n < N)%nat}) (FinitePair {n : nat | (n < K)%nat} {n : nat | (n < N)%nat} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))) (FPCM f) (fun nm : {n : nat | (n < K)%nat} * {n : nat | (n < N)%nat} => Fmul f (Fmul f (A x (snd nm)) (B (snd nm) (fst nm))) (C (fst nm) y)) (fun (nm : {n : nat | (n < N)%nat} * {n : nat | (n < K)%nat}) => (snd nm, fst nm)) H1).
+rewrite - (MySumF2BijectiveSame ({n : nat | (n < N)} * {n : nat | (n < K)}) (FinitePair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K))) ({n : nat | (n < K)} * {n : nat | (n < N)}) (FinitePair {n : nat | (n < K)} {n : nat | (n < N)} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))) (FPCM f) (fun nm : {n : nat | (n < K)} * {n : nat | (n < N)} => Fmul f (Fmul f (A x (snd nm)) (B (snd nm) (fst nm))) (C (fst nm) y)) (fun (nm : {n : nat | (n < N)} * {n : nat | (n < K)}) => (snd nm, fst nm)) H1).
 reflexivity.
 simpl.
-suff: (forall u : ({n : nat | (n < K)%nat} * {n : nat | (n < N)%nat}), proj1_sig (FinitePair {n : nat | (n < K)%nat} {n : nat | (n < N)%nat} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))) u -> proj1_sig (FinitePair {n : nat | (n < N)%nat} {n : nat | (n < K)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)%nat}) (CountFinite K))) ((fun nm : {n : nat | (n < K)%nat} * {n : nat | (n < N)%nat} => (snd nm, fst nm)) u)).
+suff: (forall u : ({n : nat | (n < K)} * {n : nat | (n < N)}), proj1_sig (FinitePair {n : nat | (n < K)} {n : nat | (n < N)} (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))) u -> proj1_sig (FinitePair {n : nat | (n < N)} {n : nat | (n < K)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (exist (Finite (Count K)) (Full_set {n : nat | (n < K)}) (CountFinite K))) ((fun nm : {n : nat | (n < K)} * {n : nat | (n < N)} => (snd nm, fst nm)) u)).
 move=> H2.
-exists (fun u : {u : {n : nat | (n < K)%nat} * {n : nat | (n < N)%nat} | Full_set {n : nat | (n < K)%nat} (fst u) /\ Full_set {n : nat | (n < N)%nat} (snd u)} => exist (fun uv : {n : nat | (n < N)%nat} * {n : nat | (n < K)%nat} => Full_set {n : nat | (n < N)%nat} (fst uv) /\ Full_set {n : nat | (n < K)%nat} (snd uv)) (snd (proj1_sig u), fst (proj1_sig u)) (H2 (proj1_sig u) (proj2_sig u))).
+exists (fun u : {u : {n : nat | (n < K)} * {n : nat | (n < N)} | Full_set {n : nat | (n < K)} (fst u) /\ Full_set {n : nat | (n < N)} (snd u)} => exist (fun uv : {n : nat | (n < N)} * {n : nat | (n < K)} => Full_set {n : nat | (n < N)} (fst uv) /\ Full_set {n : nat | (n < K)} (snd uv)) (snd (proj1_sig u), fst (proj1_sig u)) (H2 (proj1_sig u) (proj2_sig u))).
 apply conj.
 move=> u.
 apply sig_map.
@@ -314,7 +316,7 @@ apply functional_extensionality.
 move=> y.
 unfold Mplus.
 unfold Mmult.
-apply (FiniteSetInduction {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+apply (FiniteSetInduction {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -327,11 +329,11 @@ rewrite MySumF2Add.
 rewrite MySumF2Add.
 rewrite H4.
 simpl.
-rewrite - (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (Fmul f (A x b0) (B b0 y))) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (C b0 y))).
-rewrite (Fadd_assoc f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (Fmul f (A x b0) (B b0 y)) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y)))).
-rewrite (Fadd_comm f (Fmul f (A x b0) (B b0 y)) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y)))).
-rewrite - (Fadd_assoc f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (B b0 y))).
-rewrite (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y)))) (Fmul f (A x b0) (B b0 y)) (Fmul f (A x b0) (C b0 y))).
+rewrite - (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (Fmul f (A x b0) (B b0 y))) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (C b0 y))).
+rewrite (Fadd_assoc f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (Fmul f (A x b0) (B b0 y)) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y)))).
+rewrite (Fadd_comm f (Fmul f (A x b0) (B b0 y)) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y)))).
+rewrite - (Fadd_assoc f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (B b0 y))).
+rewrite (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (B n y))) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y)))) (Fmul f (A x b0) (B b0 y)) (Fmul f (A x b0) (C b0 y))).
 rewrite (Fmul_add_distr_l f).
 reflexivity.
 apply H3.
@@ -348,7 +350,7 @@ apply functional_extensionality.
 move=> y.
 unfold Mplus.
 unfold Mmult.
-apply (FiniteSetInduction {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+apply (FiniteSetInduction {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -361,11 +363,11 @@ rewrite MySumF2Add.
 rewrite MySumF2Add.
 rewrite H4.
 simpl.
-rewrite - (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (C b0 y))) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y))) (Fmul f (B x b0) (C b0 y))).
-rewrite (Fadd_assoc f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (C b0 y)) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y)))).
-rewrite (Fadd_comm f (Fmul f (A x b0) (C b0 y)) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y)))).
-rewrite - (Fadd_assoc f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y))) (Fmul f (A x b0) (C b0 y))).
-rewrite (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (MySumF2 {n : nat | (n < N)%nat} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y)))) (Fmul f (A x b0) (C b0 y)) (Fmul f (B x b0) (C b0 y))).
+rewrite - (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (C b0 y))) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y))) (Fmul f (B x b0) (C b0 y))).
+rewrite (Fadd_assoc f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (Fmul f (A x b0) (C b0 y)) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y)))).
+rewrite (Fadd_comm f (Fmul f (A x b0) (C b0 y)) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y)))).
+rewrite - (Fadd_assoc f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y))) (Fmul f (A x b0) (C b0 y))).
+rewrite (Fadd_assoc f (Fadd f (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (A x n) (C n y))) (MySumF2 {n : nat | (n < N)} B0 (FPCM f) (fun n : Count N => Fmul f (B x n) (C n y)))) (Fmul f (A x b0) (C b0 y)) (Fmul f (B x b0) (C b0 y))).
 rewrite (Fmul_add_distr_r f).
 reflexivity.
 apply H3.
@@ -373,7 +375,7 @@ apply H3.
 apply H3.
 Qed.
 
-Definition VMmult (f : Field) (M N : nat) := fun (c : FT f) (A : Matrix f M N) (x : {n : nat | (n < M)%nat}) (y : {n : nat | (n < N)%nat}) => (Fmul f c (A x y)).
+Definition VMmult (f : Field) (M N : nat) := fun (c : FT f) (A : Matrix f M N) (x : {n : nat | (n < M)}) (y : {n : nat | (n < N)}) => (Fmul f c (A x y)).
 
 Lemma VMmult_plus_distr_l : forall (f : Field) (M N : nat) (c : FT f) (A B : Matrix f M N), (VMmult f M N c (Mplus f M N A B)) = (Mplus f M N (VMmult f M N c A) (VMmult f M N c B)).
 Proof.
@@ -415,7 +417,7 @@ move=> y.
 apply Fmul_I_l.
 Qed.
 
-Definition MTranspose (f : Field) (M N : nat) := fun (A : Matrix f M N) (x : {n : nat | (n < N)%nat}) (y : {n : nat | (n < M)%nat}) => A y x.
+Definition MTranspose (f : Field) (M N : nat) := fun (A : Matrix f M N) (x : {n : nat | (n < N)}) (y : {n : nat | (n < M)}) => A y x.
 
 Lemma MTransPlus : forall (f : Field) (M N : nat) (A B : Matrix f M N), (MTranspose f M N (Mplus f M N A B)) = (Mplus f N M (MTranspose f M N A) (MTranspose f M N B)).
 Proof.
@@ -465,30 +467,30 @@ move=> y.
 reflexivity.
 Qed.
 
-Lemma blockdividesub : forall (m1 m2 : nat) (x : {n : nat | (n < m1 + m2)%nat}), (m1 <= proj1_sig x)%nat -> {y : {n : nat | (n < m2)%nat} | (m1 + proj1_sig y = proj1_sig x)%nat}.
+Lemma blockdividesub : forall (m1 m2 : nat) (x : {n : nat | (n < m1 + m2)}), (m1 <= proj1_sig x) -> {y : {n : nat | (n < m2)} | (m1 + proj1_sig y = proj1_sig x)}.
 Proof.
 move=> m1 m2 x H1.
-suff: ((proj1_sig x - m1) < m2)%nat.
+suff: ((proj1_sig x - m1) < m2).
 move=> H2.
-exists (exist (fun n : nat => (n < m2)%nat) (proj1_sig x - m1)%nat H2).
+exists (exist (fun n : nat => (n < m2)) (proj1_sig x - m1) H2).
 unfold proj1_sig at 1.
 apply (le_plus_minus_r m1 (proj1_sig x) H1).
-apply (plus_lt_reg_l (proj1_sig x - m1)%nat m2 m1).
+apply (plus_lt_reg_l (proj1_sig x - m1) m2 m1).
 rewrite (le_plus_minus_r m1 (proj1_sig x) H1).
 apply (proj2_sig x).
 Qed.
 
-Definition MBlockH := fun (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N) (x : {n : nat | (n < M1 + M2)%nat}) (y : {n : nat | (n < N)%nat}) => match (le_lt_dec M1 (proj1_sig x)) with
+Definition MBlockH := fun (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N) (x : {n : nat | (n < M1 + M2)}) (y : {n : nat | (n < N)}) => match (le_lt_dec M1 (proj1_sig x)) with
   | left a => A2 (proj1_sig (blockdividesub M1 M2 x a)) y
-  | right b => A1 (exist (fun (n : nat) => (n < M1)%nat) (proj1_sig x) b) y
+  | right b => A1 (exist (fun (n : nat) => (n < M1)) (proj1_sig x) b) y
 end.
 
-Definition MBlockW := fun (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2) (x : {n : nat | (n < M)%nat}) (y : {n : nat | (n < N1 + N2)%nat}) => match (le_lt_dec N1 (proj1_sig y)) with
+Definition MBlockW := fun (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2) (x : {n : nat | (n < M)}) (y : {n : nat | (n < N1 + N2)}) => match (le_lt_dec N1 (proj1_sig y)) with
   | left a => A2 x (proj1_sig (blockdividesub N1 N2 y a))
-  | right b => A1 x (exist (fun (n : nat) => (n < N1)%nat) (proj1_sig y) b)
+  | right b => A1 x (exist (fun (n : nat) => (n < N1)) (proj1_sig y) b)
 end.
 
-Lemma MBlockHPlus : forall (f : Field) (M1 M2 N : nat) (A1 B1 : Matrix f M1 N) (A2 B2 : Matrix f M2 N), Mplus f (M1 + M2)%nat N (MBlockH f M1 M2 N A1 A2) (MBlockH f M1 M2 N B1 B2) = MBlockH f M1 M2 N (Mplus f M1 N A1 B1) (Mplus f M2 N A2 B2).
+Lemma MBlockHPlus : forall (f : Field) (M1 M2 N : nat) (A1 B1 : Matrix f M1 N) (A2 B2 : Matrix f M2 N), Mplus f (M1 + M2) N (MBlockH f M1 M2 N A1 A2) (MBlockH f M1 M2 N B1 B2) = MBlockH f M1 M2 N (Mplus f M1 N A1 B1) (Mplus f M2 N A2 B2).
 Proof.
 move=> f M1 M2 N A1 B1 A2 B2.
 apply functional_extensionality.
@@ -504,7 +506,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockWPlus : forall (f : Field) (M N1 N2 : nat) (A1 B1 : Matrix f M N1) (A2 B2 : Matrix f M N2), Mplus f M (N1 + N2)%nat (MBlockW f M N1 N2 A1 A2) (MBlockW f M N1 N2 B1 B2) = MBlockW f M N1 N2 (Mplus f M N1 A1 B1) (Mplus f M N2 A2 B2).
+Lemma MBlockWPlus : forall (f : Field) (M N1 N2 : nat) (A1 B1 : Matrix f M N1) (A2 B2 : Matrix f M N2), Mplus f M (N1 + N2) (MBlockW f M N1 N2 A1 A2) (MBlockW f M N1 N2 B1 B2) = MBlockW f M N1 N2 (Mplus f M N1 A1 B1) (Mplus f M N2 A2 B2).
 Proof.
 move=> f M N1 N2 A1 B1 A2 B2.
 apply functional_extensionality.
@@ -520,7 +522,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockHOpp : forall (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N), Mopp f (M1 + M2)%nat N (MBlockH f M1 M2 N A1 A2) = MBlockH f M1 M2 N (Mopp f M1 N A1) (Mopp f M2 N A2).
+Lemma MBlockHOpp : forall (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N), Mopp f (M1 + M2) N (MBlockH f M1 M2 N A1 A2) = MBlockH f M1 M2 N (Mopp f M1 N A1) (Mopp f M2 N A2).
 Proof.
 move=> f M1 M2 N A1 A2.
 apply functional_extensionality.
@@ -536,7 +538,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockWOpp : forall (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2), Mopp f M (N1 + N2)%nat (MBlockW f M N1 N2 A1 A2) = MBlockW f M N1 N2 (Mopp f M N1 A1) (Mopp f M N2 A2).
+Lemma MBlockWOpp : forall (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2), Mopp f M (N1 + N2) (MBlockW f M N1 N2 A1 A2) = MBlockW f M N1 N2 (Mopp f M N1 A1) (Mopp f M N2 A2).
 Proof.
 move=> f M N1 N2 A1 A2.
 apply functional_extensionality.
@@ -552,7 +554,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockHMult : forall (f : Field) (M1 M2 N K : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N) (B : Matrix f N K), Mmult f (M1 + M2)%nat N K (MBlockH f M1 M2 N A1 A2) B = MBlockH f M1 M2 K (Mmult f M1 N K A1 B) (Mmult f M2 N K A2 B).
+Lemma MBlockHMult : forall (f : Field) (M1 M2 N K : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N) (B : Matrix f N K), Mmult f (M1 + M2) N K (MBlockH f M1 M2 N A1 A2) B = MBlockH f M1 M2 K (Mmult f M1 N K A1 B) (Mmult f M2 N K A2 B).
 Proof.
 move=> f M1 M2 N K A1 A2 B.
 apply functional_extensionality.
@@ -568,7 +570,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockWMult : forall (f : Field) (M N K1 K2 : nat) (A : Matrix f M N) (B1 : Matrix f N K1) (B2 : Matrix f N K2), Mmult f M N (K1 + K2)%nat A (MBlockW f N K1 K2 B1 B2) = MBlockW f M K1 K2 (Mmult f M N K1 A B1) (Mmult f M N K2 A B2).
+Lemma MBlockWMult : forall (f : Field) (M N K1 K2 : nat) (A : Matrix f M N) (B1 : Matrix f N K1) (B2 : Matrix f N K2), Mmult f M N (K1 + K2) A (MBlockW f N K1 K2 B1 B2) = MBlockW f M K1 K2 (Mmult f M N K1 A B1) (Mmult f M N K2 A B2).
 Proof.
 move=> f M N K1 K2 A B1 B2.
 apply functional_extensionality.
@@ -584,7 +586,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockHWMult : forall (f : Field) (M N1 N2 K : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2) (B1 : Matrix f N1 K) (B2 : Matrix f N2 K), Mmult f M (N1 + N2)%nat K (MBlockW f M N1 N2 A1 A2) (MBlockH f N1 N2 K B1 B2) = Mplus f M K (Mmult f M N1 K A1 B1) (Mmult f M N2 K A2 B2).
+Lemma MBlockHWMult : forall (f : Field) (M N1 N2 K : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2) (B1 : Matrix f N1 K) (B2 : Matrix f N2 K), Mmult f M (N1 + N2) K (MBlockW f M N1 N2 A1 A2) (MBlockH f N1 N2 K B1 B2) = Mplus f M K (Mmult f M N1 K A1 B1) (Mmult f M N2 K A2 B2).
 Proof.
 move=> f M N1 N2 K A1 A2 B1 B2.
 apply functional_extensionality.
@@ -595,68 +597,68 @@ unfold Mmult.
 unfold Mplus.
 unfold MBlockH.
 unfold MBlockW.
-rewrite (MySumF2Excluded {n : nat | (n < N1 + N2)%nat} (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
+rewrite (MySumF2Excluded {n : nat | (n < N1 + N2)} (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
   | left a => A2 x (proj1_sig (blockdividesub N1 N2 n a))
-  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b)
+  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b)
 end match le_lt_dec N1 (proj1_sig n) with
   | left a => B2 (proj1_sig (blockdividesub N1 N2 n a)) y
-  | right b => B1 (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b) y
-end) (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (fun (m : {n : nat | (n < N1 + N2)%nat}) => (proj1_sig m < N1)%nat)).
-suff: ((MySumF2 {n : nat | (n < N1 + N2)%nat} (FiniteIntersection {n : nat | (n < N1 + N2)%nat} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat)) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
+  | right b => B1 (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b) y
+end) (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (fun (m : {n : nat | (n < N1 + N2)}) => (proj1_sig m < N1))).
+suff: ((MySumF2 {n : nat | (n < N1 + N2)} (FiniteIntersection {n : nat | (n < N1 + N2)} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1))) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
   | left a => A2 x (proj1_sig (blockdividesub N1 N2 n a))
-  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b)
+  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b)
 end match le_lt_dec N1 (proj1_sig n) with
   | left a => B2 (proj1_sig (blockdividesub N1 N2 n a)) y
-  | right b => B1 (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b) y
-end)) = (MySumF2 {n : nat | (n < N1)%nat} (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)%nat}) (CountFinite N1)) (FPCM f) (fun n : Count N1 => Fmul f (A1 x n) (B1 n y)))).
+  | right b => B1 (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b) y
+end)) = (MySumF2 {n : nat | (n < N1)} (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)}) (CountFinite N1)) (FPCM f) (fun n : Count N1 => Fmul f (A1 x n) (B1 n y)))).
 move=> H1.
 rewrite H1.
-suff: ((MySumF2 {n : nat | (n < N1 + N2)%nat} (FiniteIntersection {n : nat | (n < N1 + N2)%nat} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (Complement {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat))) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
+suff: ((MySumF2 {n : nat | (n < N1 + N2)} (FiniteIntersection {n : nat | (n < N1 + N2)} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (Complement {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1)))) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
   | left a => A2 x (proj1_sig (blockdividesub N1 N2 n a))
-  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b)
+  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b)
 end match le_lt_dec N1 (proj1_sig n) with
   | left a => B2 (proj1_sig (blockdividesub N1 N2 n a)) y
-  | right b => B1 (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b) y
-end)) = (MySumF2 {n : nat | (n < N2)%nat} (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)%nat}) (CountFinite N2)) (FPCM f) (fun n : Count N2 => Fmul f (A2 x n) (B2 n y)))).
+  | right b => B1 (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b) y
+end)) = (MySumF2 {n : nat | (n < N2)} (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)}) (CountFinite N2)) (FPCM f) (fun n : Count N2 => Fmul f (A2 x n) (B2 n y)))).
 move=> H2.
 rewrite H2.
 reflexivity.
-suff: (forall (u : {n : nat | (n < N2)%nat}), (N1 + proj1_sig u < N1 + N2)%nat).
+suff: (forall (u : {n : nat | (n < N2)}), (N1 + proj1_sig u < N1 + N2)).
 move=> H2.
-suff: (forall (u : {n : nat | (n < N2)%nat}), proj1_sig (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)%nat}) (CountFinite N2)) u -> proj1_sig (FiniteIntersection {n : nat | (n < N1 + N2)%nat} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (Complement {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat))) ((fun (u1 : {n : nat | (n < N2)%nat}) => (exist (fun (n : nat) => (n < N1 + N2)%nat) (N1 + proj1_sig u1)%nat (H2 u1))) u)).
+suff: (forall (u : {n : nat | (n < N2)}), proj1_sig (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)}) (CountFinite N2)) u -> proj1_sig (FiniteIntersection {n : nat | (n < N1 + N2)} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (Complement {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1)))) ((fun (u1 : {n : nat | (n < N2)}) => (exist (fun (n : nat) => (n < N1 + N2)) (N1 + proj1_sig u1) (H2 u1))) u)).
 move=> H3.
-rewrite - (MySumF2BijectiveSame {n : nat | (n < N2)%nat} (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)%nat}) (CountFinite N2)) {n : nat | (n < N1 + N2)%nat} (FiniteIntersection {n : nat | (n < N1 + N2)%nat} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (Complement {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat))) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
+rewrite - (MySumF2BijectiveSame {n : nat | (n < N2)} (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)}) (CountFinite N2)) {n : nat | (n < N1 + N2)} (FiniteIntersection {n : nat | (n < N1 + N2)} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (Complement {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1)))) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
   | left a => A2 x (proj1_sig (blockdividesub N1 N2 n a))
-  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b)
+  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b)
 end match le_lt_dec N1 (proj1_sig n) with
   | left a => B2 (proj1_sig (blockdividesub N1 N2 n a)) y
-  | right b => B1 (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b) y
-end) (fun (u1 : {n : nat | (n < N2)%nat}) => (exist (fun (n : nat) => (n < N1 + N2)%nat) (N1 + proj1_sig u1)%nat (H2 u1))) H3).
-apply (MySumF2Same {n : nat | (n < N2)%nat} (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)%nat}) (CountFinite N2)) (FPCM f)).
+  | right b => B1 (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b) y
+end) (fun (u1 : {n : nat | (n < N2)}) => (exist (fun (n : nat) => (n < N1 + N2)) (N1 + proj1_sig u1) (H2 u1))) H3).
+apply (MySumF2Same {n : nat | (n < N2)} (exist (Finite (Count N2)) (Full_set {n : nat | (n < N2)}) (CountFinite N2)) (FPCM f)).
 simpl.
 move=> u H4.
 elim (le_lt_dec N1 (N1 + proj1_sig u)).
 move=> H5.
-suff: (u = (proj1_sig (blockdividesub N1 N2 (exist (fun n : nat => (n < N1 + N2)%nat) (N1 + proj1_sig u)%nat (H2 u)) H5))).
+suff: (u = (proj1_sig (blockdividesub N1 N2 (exist (fun n : nat => (n < N1 + N2)) (N1 + proj1_sig u) (H2 u)) H5))).
 move=> H6.
 rewrite {7} H6.
 rewrite {11} H6.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig u) (proj1_sig (proj1_sig (blockdividesub N1 N2 (exist (fun n : nat => (n < N1 + N2)%nat) (N1 + proj1_sig u)%nat (H2 u)) H5))) N1).
-rewrite (proj2_sig (blockdividesub N1 N2 (exist (fun n : nat => (n < N1 + N2)%nat) (N1 + proj1_sig u)%nat (H2 u)) H5)).
+apply (plus_reg_l (proj1_sig u) (proj1_sig (proj1_sig (blockdividesub N1 N2 (exist (fun n : nat => (n < N1 + N2)) (N1 + proj1_sig u) (H2 u)) H5))) N1).
+rewrite (proj2_sig (blockdividesub N1 N2 (exist (fun n : nat => (n < N1 + N2)) (N1 + proj1_sig u) (H2 u)) H5)).
 reflexivity.
 move=> H5.
 apply False_ind.
-apply (lt_not_le (N1 + proj1_sig u)%nat N1 H5).
+apply (lt_not_le (N1 + proj1_sig u) N1 H5).
 rewrite - {1} (plus_0_r N1).
 apply (plus_le_compat_l 0 (proj1_sig u) N1 (le_0_n (proj1_sig u))).
 simpl.
-suff: (forall (x : {u : {n : nat | (n < N1 + N2)%nat} | Intersection {n : nat | (n < N1 + N2)%nat} (Complement {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat)) (Full_set {n : nat | (n < N1 + N2)%nat}) u}), (proj1_sig (proj1_sig x) - N1 < N2)%nat).
+suff: (forall (x : {u : {n : nat | (n < N1 + N2)} | Intersection {n : nat | (n < N1 + N2)} (Complement {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1))) (Full_set {n : nat | (n < N1 + N2)}) u}), (proj1_sig (proj1_sig x) - N1 < N2)).
 move=> H4.
-suff: (forall (x : {u : {n : nat | (n < N1 + N2)%nat} | Intersection {n : nat | (n < N1 + N2)%nat} (Complement {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat)) (Full_set {n : nat | (n < N1 + N2)%nat}) u}), Full_set {n : nat | (n < N2)%nat} (exist (fun (n : nat) => (n < N2)%nat) (proj1_sig (proj1_sig x) - N1)%nat (H4 x))).
+suff: (forall (x : {u : {n : nat | (n < N1 + N2)} | Intersection {n : nat | (n < N1 + N2)} (Complement {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1))) (Full_set {n : nat | (n < N1 + N2)}) u}), Full_set {n : nat | (n < N2)} (exist (fun (n : nat) => (n < N2)) (proj1_sig (proj1_sig x) - N1) (H4 x))).
 move=> H5.
-exists (fun (x : {u : {n : nat | (n < N1 + N2)%nat} | Intersection {n : nat | (n < N1 + N2)%nat} (Complement {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat)) (Full_set {n : nat | (n < N1 + N2)%nat}) u}) => exist (fun (u : {n : nat | (n < N2)%nat}) => Full_set {n : nat | (n < N2)%nat} u) (exist (fun (n : nat) => (n < N2)%nat) (proj1_sig (proj1_sig x) - N1)%nat (H4 x)) (H5 x)).
+exists (fun (x : {u : {n : nat | (n < N1 + N2)} | Intersection {n : nat | (n < N1 + N2)} (Complement {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1))) (Full_set {n : nat | (n < N1 + N2)}) u}) => exist (fun (u : {n : nat | (n < N2)}) => Full_set {n : nat | (n < N2)} u) (exist (fun (n : nat) => (n < N2)) (proj1_sig (proj1_sig x) - N1) (H4 x)) (H5 x)).
 apply conj.
 move=> x0.
 apply sig_map.
@@ -670,19 +672,19 @@ simpl.
 apply sig_map.
 simpl.
 apply (le_plus_minus_r N1 (proj1_sig (proj1_sig y0))).
-elim (le_or_lt N1 (proj1_sig (proj1_sig y0))%nat).
+elim (le_or_lt N1 (proj1_sig (proj1_sig y0))).
 apply.
 elim (proj2_sig y0).
 move=> y1 H6 H7 H8.
 apply False_ind.
 apply (H6 H8).
 move=> x0.
-apply (Full_intro {n : nat | (n < N2)%nat} (exist (fun n : nat => (n < N2)%nat) (proj1_sig (proj1_sig x0) - N1)%nat (H4 x0))).
+apply (Full_intro {n : nat | (n < N2)} (exist (fun n : nat => (n < N2)) (proj1_sig (proj1_sig x0) - N1) (H4 x0))).
 move=> x0.
 apply (plus_lt_reg_l (proj1_sig (proj1_sig x0) - N1) N2 N1).
 rewrite (le_plus_minus_r N1 (proj1_sig (proj1_sig x0))).
 apply (proj2_sig (proj1_sig x0)).
-elim (le_or_lt N1 (proj1_sig (proj1_sig x0))%nat).
+elim (le_or_lt N1 (proj1_sig (proj1_sig x0))).
 apply.
 elim (proj2_sig x0).
 move=> x1 H4 H5 H6.
@@ -691,26 +693,26 @@ apply (H4 H6).
 move=> u H3.
 unfold FiniteIntersection.
 simpl.
-apply (Intersection_intro {n : nat | (n < N1 + N2)%nat}).
+apply (Intersection_intro {n : nat | (n < N1 + N2)}).
 apply (le_not_lt N1 (N1 + proj1_sig u)).
 rewrite - {1} (plus_0_r N1).
 apply (plus_le_compat_l 0 (proj1_sig u) N1 (le_0_n (proj1_sig u))).
-apply (Full_intro {n : nat | (n < N1 + N2)%nat}).
+apply (Full_intro {n : nat | (n < N1 + N2)}).
 move=> u.
 apply (plus_lt_compat_l (proj1_sig u) N2 N1).
 apply (proj2_sig u).
-suff: (forall (u : {n : nat | (n < N1)%nat}), (proj1_sig u < N1 + N2)%nat).
+suff: (forall (u : {n : nat | (n < N1)}), (proj1_sig u < N1 + N2)).
 move=> H1.
-suff: (forall (u : {n : nat | (n < N1)%nat}), proj1_sig (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)%nat}) (CountFinite N1)) u -> proj1_sig (FiniteIntersection {n : nat | (n < N1 + N2)%nat} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat)) ((fun (u1 : {n : nat | (n < N1)%nat}) => (exist (fun (n : nat) => (n < N1 + N2)%nat) (proj1_sig u1)%nat (H1 u1))) u)).
+suff: (forall (u : {n : nat | (n < N1)}), proj1_sig (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)}) (CountFinite N1)) u -> proj1_sig (FiniteIntersection {n : nat | (n < N1 + N2)} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1))) ((fun (u1 : {n : nat | (n < N1)}) => (exist (fun (n : nat) => (n < N1 + N2)) (proj1_sig u1) (H1 u1))) u)).
 move=> H2.
-rewrite - (MySumF2BijectiveSame {n : nat | (n < N1)%nat} (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)%nat}) (CountFinite N1)) {n : nat | (n < N1 + N2)%nat} (FiniteIntersection {n : nat | (n < N1 + N2)%nat} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)%nat}) (CountFinite (N1 + N2))) (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat)) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
+rewrite - (MySumF2BijectiveSame {n : nat | (n < N1)} (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)}) (CountFinite N1)) {n : nat | (n < N1 + N2)} (FiniteIntersection {n : nat | (n < N1 + N2)} (exist (Finite (Count (N1 + N2))) (Full_set {n : nat | (n < N1 + N2)}) (CountFinite (N1 + N2))) (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1))) (FPCM f) (fun n : Count (N1 + N2) => Fmul f match le_lt_dec N1 (proj1_sig n) with
   | left a => A2 x (proj1_sig (blockdividesub N1 N2 n a))
-  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b)
+  | right b => A1 x (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b)
 end match le_lt_dec N1 (proj1_sig n) with
   | left a => B2 (proj1_sig (blockdividesub N1 N2 n a)) y
-  | right b => B1 (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig n) b) y
-end) (fun (u1 : {n : nat | (n < N1)%nat}) => (exist (fun (n : nat) => (n < N1 + N2)%nat) (proj1_sig u1)%nat (H1 u1))) H2).
-apply (MySumF2Same {n : nat | (n < N1)%nat} (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)%nat}) (CountFinite N1)) (FPCM f)).
+  | right b => B1 (exist (fun n0 : nat => (n0 < N1)) (proj1_sig n) b) y
+end) (fun (u1 : {n : nat | (n < N1)}) => (exist (fun (n : nat) => (n < N1 + N2)) (proj1_sig u1) (H1 u1))) H2).
+apply (MySumF2Same {n : nat | (n < N1)} (exist (Finite (Count N1)) (Full_set {n : nat | (n < N1)}) (CountFinite N1)) (FPCM f)).
 simpl.
 move=> u H3.
 elim (le_lt_dec N1 (proj1_sig u)).
@@ -718,7 +720,7 @@ move=> H4.
 apply False_ind.
 apply (lt_not_le (proj1_sig u) N1 (proj2_sig u) H4).
 move=> H4.
-suff: (u = (exist (fun n0 : nat => (n0 < N1)%nat) (proj1_sig u) H4)).
+suff: (u = (exist (fun n0 : nat => (n0 < N1)) (proj1_sig u) H4)).
 move=> H5.
 rewrite {3} H5.
 rewrite {4} H5.
@@ -726,11 +728,11 @@ reflexivity.
 apply sig_map.
 reflexivity.
 simpl.
-suff: (forall (x : {u : {n : nat | (n < N1 + N2)%nat} | Intersection {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat) (Full_set {n : nat | (n < N1 + N2)%nat}) u}), (proj1_sig (proj1_sig x) < N1)%nat).
+suff: (forall (x : {u : {n : nat | (n < N1 + N2)} | Intersection {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1)) (Full_set {n : nat | (n < N1 + N2)}) u}), (proj1_sig (proj1_sig x) < N1)).
 move=> H3.
-suff: (forall (x : {u : {n : nat | (n < N1 + N2)%nat} | Intersection {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat) (Full_set {n : nat | (n < N1 + N2)%nat}) u}), Full_set {n : nat | (n < N1)%nat} (exist (fun (n : nat) => (n < N1)%nat) (proj1_sig (proj1_sig x))%nat (H3 x))).
+suff: (forall (x : {u : {n : nat | (n < N1 + N2)} | Intersection {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1)) (Full_set {n : nat | (n < N1 + N2)}) u}), Full_set {n : nat | (n < N1)} (exist (fun (n : nat) => (n < N1)) (proj1_sig (proj1_sig x)) (H3 x))).
 move=> H4.
-exists (fun (x : {u : {n : nat | (n < N1 + N2)%nat} | Intersection {n : nat | (n < N1 + N2)%nat} (fun m : {n : nat | (n < N1 + N2)%nat} => (proj1_sig m < N1)%nat) (Full_set {n : nat | (n < N1 + N2)%nat}) u}) => exist (fun (u : {n : nat | (n < N1)%nat}) => Full_set {n : nat | (n < N1)%nat} u) (exist (fun (n : nat) => (n < N1)%nat) (proj1_sig (proj1_sig x))%nat (H3 x)) (H4 x)).
+exists (fun (x : {u : {n : nat | (n < N1 + N2)} | Intersection {n : nat | (n < N1 + N2)} (fun m : {n : nat | (n < N1 + N2)} => (proj1_sig m < N1)) (Full_set {n : nat | (n < N1 + N2)}) u}) => exist (fun (u : {n : nat | (n < N1)}) => Full_set {n : nat | (n < N1)} u) (exist (fun (n : nat) => (n < N1)) (proj1_sig (proj1_sig x)) (H3 x)) (H4 x)).
 apply conj.
 move=> x0.
 apply sig_map.
@@ -745,23 +747,23 @@ apply sig_map.
 simpl.
 reflexivity.
 move=> x0.
-apply (Full_intro {n : nat | (n < N1)%nat} (exist (fun n : nat => (n < N1)%nat) (proj1_sig (proj1_sig x0)) (H3 x0))).
+apply (Full_intro {n : nat | (n < N1)} (exist (fun n : nat => (n < N1)) (proj1_sig (proj1_sig x0)) (H3 x0))).
 move=> x0.
 elim (proj2_sig x0).
 move=> x1 H3 H4.
 apply H3.
 simpl.
 move=> u H2.
-apply (Intersection_intro {n : nat | (n < N1 + N2)%nat}).
+apply (Intersection_intro {n : nat | (n < N1 + N2)}).
 apply (proj2_sig u).
-apply (Full_intro {n : nat | (n < N1 + N2)%nat} (exist (fun n : nat => (n < N1 + N2)%nat) (proj1_sig u) (H1 u))).
+apply (Full_intro {n : nat | (n < N1 + N2)} (exist (fun n : nat => (n < N1 + N2)) (proj1_sig u) (H1 u))).
 move=> u.
-apply (lt_le_trans (proj1_sig u) N1 (N1 + N2)%nat (proj2_sig u)).
+apply (lt_le_trans (proj1_sig u) N1 (N1 + N2) (proj2_sig u)).
 rewrite - {1} (plus_0_r N1).
 apply (plus_le_compat_l 0 N2 N1 (le_0_n N2)).
 Qed.
 
-Lemma MBlockHVMult : forall (f : Field) (M1 M2 N : nat) (c : FT f) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N), VMmult f (M1 + M2)%nat N c (MBlockH f M1 M2 N A1 A2) = MBlockH f M1 M2 N (VMmult f M1 N c A1) (VMmult f M2 N c A2).
+Lemma MBlockHVMult : forall (f : Field) (M1 M2 N : nat) (c : FT f) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N), VMmult f (M1 + M2) N c (MBlockH f M1 M2 N A1 A2) = MBlockH f M1 M2 N (VMmult f M1 N c A1) (VMmult f M2 N c A2).
 Proof.
 move=> f M1 M2 N c A1 A2.
 apply functional_extensionality.
@@ -777,7 +779,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockWVMult : forall (f : Field) (M N1 N2 : nat) (c : FT f) (A1 : Matrix f M N1) (A2 : Matrix f M N2), VMmult f M (N1 + N2)%nat c (MBlockW f M N1 N2 A1 A2) = MBlockW f M N1 N2 (VMmult f M N1 c A1) (VMmult f M N2 c A2).
+Lemma MBlockWVMult : forall (f : Field) (M N1 N2 : nat) (c : FT f) (A1 : Matrix f M N1) (A2 : Matrix f M N2), VMmult f M (N1 + N2) c (MBlockW f M N1 N2 A1 A2) = MBlockW f M N1 N2 (VMmult f M N1 c A1) (VMmult f M N2 c A2).
 Proof.
 move=> f M N1 N2 c A1 A2.
 apply functional_extensionality.
@@ -793,7 +795,7 @@ move=> H1.
 reflexivity.
 Qed.
 
-Lemma MBlockHTranspose : forall (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N), MTranspose f (M1 + M2)%nat N (MBlockH f M1 M2 N A1 A2) = MBlockW f N M1 M2 (MTranspose f M1 N A1) (MTranspose f M2 N A2).
+Lemma MBlockHTranspose : forall (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N), MTranspose f (M1 + M2) N (MBlockH f M1 M2 N A1 A2) = MBlockW f N M1 M2 (MTranspose f M1 N A1) (MTranspose f M2 N A2).
 Proof.
 move=> f M1 M2 N A1 A2.
 apply functional_extensionality.
@@ -803,7 +805,7 @@ move=> y.
 reflexivity.
 Qed.
 
-Lemma MBlockWTranspose : forall (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2), MTranspose f M (N1 + N2)%nat (MBlockW f M N1 N2 A1 A2) = MBlockH f N1 N2 M (MTranspose f M N1 A1) (MTranspose f M N2 A2).
+Lemma MBlockWTranspose : forall (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2), MTranspose f M (N1 + N2) (MBlockW f M N1 N2 A1 A2) = MBlockH f N1 N2 M (MTranspose f M N1 A1) (MTranspose f M N2 A2).
 Proof.
 move=> f M N1 N2 A1 A2.
 apply functional_extensionality.
@@ -816,7 +818,7 @@ Qed.
 Definition Determinant (f : Field) (N : nat) (A : Matrix f N N) := MySumF2 (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (FPCM f) (fun (P : Permutation N) => Fmul f (match PermutationParity N P with
   | OFF => (FI f)
   | ON => Fopp f (FI f)
-end) (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat| (n < N) %nat}) (CountFinite N)) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => A k (proj1_sig P k)))).
+end) (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat| (n < N) }) (CountFinite N)) (FMCM f) (fun (k : {n : nat | (n < N)}) => A k (proj1_sig P k)))).
 
 Lemma DeterminantI : forall (f : Field) (N : nat), Determinant f N (MI f N) = FI f.
 Proof.
@@ -844,10 +846,10 @@ apply False_ind.
 apply H3.
 reflexivity.
 move=> u H1.
-suff: (exists (k : {n : nat | (n < N)%nat}), k <> proj1_sig u k).
+suff: (exists (k : {n : nat | (n < N)}), k <> proj1_sig u k).
 elim.
 move=> k H2.
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} k) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f)).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} k) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f)).
 rewrite MySumF2Singleton.
 unfold MI.
 elim (Nat.eq_dec (proj1_sig k) (proj1_sig (proj1_sig u k))).
@@ -861,7 +863,7 @@ simpl.
 rewrite (Fmul_O_l f).
 apply (Fmul_O_r f).
 move=> l H3.
-apply (Full_intro {n : nat | (n < N)%nat} l).
+apply (Full_intro {n : nat | (n < N)} l).
 elim H1.
 move=> p H2 H3.
 apply NNPP.
@@ -892,16 +894,16 @@ move=> f N H1.
 unfold Determinant.
 apply (MySumF2O (Permutation N)).
 move=> u H2.
-suff: ((N > O)%nat).
+suff: ((N > O)).
 move=> H3.
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} (exist (fun (k : nat) => (k < N)%nat) O H3))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} (exist (fun (k : nat) => (k < N)) O H3))).
 rewrite MySumF2Singleton.
 unfold MO.
 simpl.
 rewrite (Fmul_O_l f).
 apply (Fmul_O_r f).
 move=> k H4.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 elim (le_lt_or_eq O N (le_0_n N)).
 apply.
 move=> H3.
@@ -923,10 +925,10 @@ unfold Basics.compose.
 suff: ((fun P : Permutation N => Fmul f match PermutationParity N P with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig P k)))) = (fun x : Permutation N => Fmul f match PermutationParity N (PermutationInv N x) with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig P k)))) = (fun x : Permutation N => Fmul f match PermutationParity N (PermutationInv N x) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => MTranspose f N N A k (proj1_sig (PermutationInv N x) k))))).
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => MTranspose f N N A k (proj1_sig (PermutationInv N x) k))))).
 move=> H2.
 rewrite H2.
 reflexivity.
@@ -934,12 +936,12 @@ apply functional_extensionality.
 move=> k.
 unfold MTranspose.
 rewrite (PermutationInvParity N k).
-suff: ((exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) = FiniteIm {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig (PermutationInv N k)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+suff: ((exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) = FiniteIm {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig (PermutationInv N k)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 move=> H2.
 rewrite {1} H2.
-rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (proj1_sig (PermutationInv N k))).
+rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)} {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (proj1_sig (PermutationInv N k))).
 unfold Basics.compose.
-suff: ((fun (l : {n : nat | (n < N)%nat}) => A (proj1_sig (PermutationInv N k) l) (proj1_sig k (proj1_sig (PermutationInv N k) l))) = (fun (l : {n : nat | (n < N)%nat}) => A (proj1_sig (PermutationInv N k) l) l)).
+suff: ((fun (l : {n : nat | (n < N)}) => A (proj1_sig (PermutationInv N k) l) (proj1_sig k (proj1_sig (PermutationInv N k) l))) = (fun (l : {n : nat | (n < N)}) => A (proj1_sig (PermutationInv N k) l) l)).
 move=> H3.
 rewrite H3.
 reflexivity.
@@ -947,36 +949,36 @@ apply functional_extensionality.
 move=> l.
 unfold PermutationInv at 2.
 simpl.
-rewrite (proj2 (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig k) (proj2_sig k))) l).
+rewrite (proj2 (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig k) (proj2_sig k))) l).
 reflexivity.
 move=> u1 u2 H3 H4.
-apply (BijInj {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig (PermutationInv N k)) (proj2_sig (PermutationInv N k))).
+apply (BijInj {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig (PermutationInv N k)) (proj2_sig (PermutationInv N k))).
 apply sig_map.
 apply Extensionality_Ensembles.
 apply conj.
 move=> m H2.
-apply (Im_intro {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (Full_set {n : nat | (n < N)%nat}) (proj1_sig (PermutationInv N k)) (proj1_sig k m)).
-apply (Full_intro {n : nat | (n < N)%nat} (proj1_sig k m)).
+apply (Im_intro {n : nat | (n < N)} {n : nat | (n < N)} (Full_set {n : nat | (n < N)}) (proj1_sig (PermutationInv N k)) (proj1_sig k m)).
+apply (Full_intro {n : nat | (n < N)} (proj1_sig k m)).
 unfold PermutationInv.
 simpl.
-rewrite (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig k) (proj2_sig k))) m).
+rewrite (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig k) (proj2_sig k))) m).
 reflexivity.
 move=> m H2.
-apply (Full_intro {n : nat | (n < N)%nat} m).
+apply (Full_intro {n : nat | (n < N)} m).
 unfold PermutationInv.
 move=> u1 u2 H2 H3 H4.
 apply sig_map.
 apply functional_extensionality.
 move=> l.
-apply (BijInj {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig u1) (proj2_sig u1)))).
+apply (BijInj {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig u1) (proj2_sig u1)))).
 apply (PermutationInvSub N u1).
-rewrite (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig u1) (proj2_sig u1))) l).
-suff: (proj1_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig u1) (proj2_sig u1)) = proj1_sig (exist (fun f : {n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat} => Bijective f) (proj1_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig u1) (proj2_sig u1))) (PermutationInvSub N u1))).
+rewrite (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig u1) (proj2_sig u1))) l).
+suff: (proj1_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig u1) (proj2_sig u1)) = proj1_sig (exist (fun f : {n : nat | (n < N)} -> {n : nat | (n < N)} => Bijective f) (proj1_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig u1) (proj2_sig u1))) (PermutationInvSub N u1))).
 move=> H5.
 rewrite H5.
 rewrite H4.
 simpl.
-rewrite (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig u2) (proj2_sig u2))) l).
+rewrite (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig u2) (proj2_sig u2))) l).
 reflexivity.
 reflexivity.
 apply sig_map.
@@ -986,19 +988,19 @@ move=> p H1.
 apply (Im_intro (Permutation N) (Permutation N) (Full_set (Permutation N)) (PermutationInv N) (PermutationInv N p)).
 apply (Full_intro (Permutation N) (PermutationInv N p)).
 apply sig_map.
-apply (InvUnique {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig (PermutationInv N p))).
+apply (InvUnique {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig (PermutationInv N p))).
 apply conj.
-apply (proj2 (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig p) (proj2_sig p)))).
-apply (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig p) (proj2_sig p)))).
-apply (proj2_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig (exist (fun f0 : {n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat} => Bijective f0) (proj1_sig (BijectiveInvExist {n : nat | (n < N)%nat} {n : nat | (n < N)%nat} (proj1_sig p) (proj2_sig p))) (PermutationInvSub N p))) (proj2_sig (PermutationInv N p)))).
+apply (proj2 (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig p) (proj2_sig p)))).
+apply (proj1 (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig p) (proj2_sig p)))).
+apply (proj2_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig (exist (fun f0 : {n : nat | (n < N)} -> {n : nat | (n < N)} => Bijective f0) (proj1_sig (BijectiveInvExist {n : nat | (n < N)} {n : nat | (n < N)} (proj1_sig p) (proj2_sig p))) (PermutationInvSub N p))) (proj2_sig (PermutationInv N p)))).
 move=> k H1.
 apply (Full_intro (Permutation N) k).
 Qed.
 
-Lemma DeterminantMultiLinearityHPlus : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)%nat}) (b : {n : nat | (n < N)%nat} -> FT f), Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
+Lemma DeterminantMultiLinearityHPlus : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)}) (b : {n : nat | (n < N)} -> FT f), Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
   | left _ => Fadd f (A x y) (b y)
   | right _ => A x y
-end) = Fadd f (Determinant f N A) (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
+end) = Fadd f (Determinant f N A) (Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
   | left _ => (b y)
   | right _ => A x y
 end)).
@@ -1008,35 +1010,35 @@ unfold Determinant.
 apply (MySumF2Distr (Permutation N) (FPCM f)).
 move=> u H1.
 simpl.
-suff: ((MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+suff: ((MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => Fadd f (A k (proj1_sig u k)) (b (proj1_sig u k))
   | right _ => A k (proj1_sig u k)
-end)) = Fadd f (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig u k))) (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+end)) = Fadd f (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig u k))) (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => b (proj1_sig u k)
   | right _ => A k (proj1_sig u k)
 end))).
 move=> H2.
 rewrite H2.
 apply (Fmul_add_distr_l f).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 rewrite MySumF2Singleton.
 rewrite MySumF2Singleton.
 rewrite MySumF2Singleton.
 elim (Nat.eq_dec (proj1_sig p) (proj1_sig p)).
 move=> H2.
 simpl.
-suff: ((MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (Singleton {n : nat | (n < N)%nat} p))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+suff: ((MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (Singleton {n : nat | (n < N)} p))) (FMCM f) (fun (k : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => Fadd f (A k (proj1_sig u k)) (b (proj1_sig u k))
   | right _ => A k (proj1_sig u k)
-end)) = (MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (Singleton {n : nat | (n < N)%nat} p))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => A k (proj1_sig u k)))).
+end)) = (MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (Singleton {n : nat | (n < N)} p))) (FMCM f) (fun (k : {n : nat | (n < N)}) => A k (proj1_sig u k)))).
 move=> H3.
 rewrite H3.
-suff: ((MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (Singleton {n : nat | (n < N)%nat} p))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+suff: ((MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (Singleton {n : nat | (n < N)} p))) (FMCM f) (fun (k : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => b (proj1_sig u k)
   | right _ => A k (proj1_sig u k)
-end)) = (MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (Singleton {n : nat | (n < N)%nat} p))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => A k (proj1_sig u k)))).
+end)) = (MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (Singleton {n : nat | (n < N)} p))) (FMCM f) (fun (k : {n : nat | (n < N)}) => A k (proj1_sig u k)))).
 move=> H4.
 rewrite H4.
 apply (Fmul_add_distr_r f).
@@ -1075,35 +1077,35 @@ apply False_ind.
 apply H2.
 reflexivity.
 move=> k H2.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 move=> k H2.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 move=> k H2.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 Qed.
 
-Lemma DeterminantMultiLinearityWPlus : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)%nat}) (b : {n : nat | (n < N)%nat} -> FT f), Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+Lemma DeterminantMultiLinearityWPlus : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)}) (b : {n : nat | (n < N)} -> FT f), Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => Fadd f (A x y) (b x)
   | right _ => A x y
-end) = Fadd f (Determinant f N A) (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+end) = Fadd f (Determinant f N A) (Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => b x
   | right _ => A x y
 end)).
 Proof.
 move=> f N A p b.
-rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => Fadd f (A x y) (b x)
   | right _ => A x y
 end)).
 rewrite - (DeterminantTrans f N A).
-rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => b x
   | right _ => A x y
 end)).
 apply (DeterminantMultiLinearityHPlus f N (MTranspose f N N A) p b).
 Qed.
 
-Lemma DeterminantMultiLinearityHMult : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)%nat}) (c : FT f), Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
+Lemma DeterminantMultiLinearityHMult : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)}) (c : FT f), Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
   | left _ => Fmul f c (A x y)
   | right _ => A x y
 end) = Fmul f c (Determinant f N A).
@@ -1114,13 +1116,13 @@ apply (FiniteSetInduction (Permutation N) (exist (Finite (Permutation N)) (Full_
 suff: (forall (b : Permutation N), (Fmul f match PermutationParity N b with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => Fmul f c (A k (proj1_sig b k))
   | right _ => A k (proj1_sig b k)
 end))) = Fmul f c (Fmul f match PermutationParity N b with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig b k))))).
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig b k))))).
 move=> H1.
 apply conj.
 rewrite MySumF2Empty.
@@ -1137,8 +1139,8 @@ reflexivity.
 apply H4.
 apply H4.
 move=> b.
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 rewrite MySumF2Singleton.
 rewrite MySumF2Singleton.
 elim (Nat.eq_dec (proj1_sig p) (proj1_sig p)).
@@ -1157,10 +1159,10 @@ rewrite (Fmul_comm f c (match PermutationParity N b with
   | ON => Fopp f (FI f)
   | OFF => FI f
 end)).
-rewrite (MySumF2Same {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (Singleton {n : nat | (n < N)%nat} p))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+rewrite (MySumF2Same {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (Singleton {n : nat | (n < N)} p))) (FMCM f) (fun (k : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => Fmul f c (A k (proj1_sig b k))
   | right _ => A k (proj1_sig b k)
-end) (fun (k : {n : nat | (n < N)%nat}) => A k (proj1_sig b k))).
+end) (fun (k : {n : nat | (n < N)}) => A k (proj1_sig b k))).
 reflexivity.
 move=> u H2.
 elim (Nat.eq_dec (proj1_sig u) (proj1_sig p)).
@@ -1181,18 +1183,18 @@ apply False_ind.
 apply H1.
 reflexivity.
 move=> k H1.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 move=> k H1.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 Qed.
 
-Lemma DeterminantMultiLinearityWMult : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)%nat}) (c : FT f), Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+Lemma DeterminantMultiLinearityWMult : forall (f : Field) (N : nat) (A : Matrix f N N) (p : {n : nat | (n < N)}) (c : FT f), Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => Fmul f c (A x y)
   | right _ => A x y
 end) = Fmul f c (Determinant f N A).
 Proof.
 move=> f N A p c.
-rewrite - (DeterminantTrans f N (fun x y : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+rewrite - (DeterminantTrans f N (fun x y : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => Fmul f c (A x y)
   | right _ => A x y
 end)).
@@ -1200,7 +1202,7 @@ rewrite - (DeterminantTrans f N A).
 apply (DeterminantMultiLinearityHMult f N (MTranspose f N N A) p c).
 Qed.
 
-Lemma DeterminantSwapH : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)%nat}), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
+Lemma DeterminantSwapH : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)}), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig p) with
   | left _ => A q y
   | right _ => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
     | left _ => A p y
@@ -1228,7 +1230,7 @@ rewrite H6.
 suff: ((Fmul f match PermutationParity N b with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => A q (proj1_sig b k)
   | right _ => match Nat.eq_dec (proj1_sig k) (proj1_sig q) with
     | left _ => A p (proj1_sig b k)
@@ -1237,18 +1239,18 @@ end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : na
 end))) = Fopp f (Fmul f match PermutationParity N (PermutationCompose N b (PermutationSwap N p q)) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k))))).
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k))))).
 move=> H7.
 rewrite H7.
 rewrite (Fopp_add_distr f).
 reflexivity.
-suff: ((MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+suff: ((MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => A q (proj1_sig b k)
   | right _ => match Nat.eq_dec (proj1_sig k) (proj1_sig q) with
     | left _ => A p (proj1_sig b k)
     | right _ => A k (proj1_sig b k)
   end
-end)) = (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k)))).
+end)) = (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k)))).
 move=> H7.
 rewrite H7.
 rewrite (PermutationComposeParity N b (PermutationSwap N p q)).
@@ -1268,15 +1270,15 @@ unfold PermutationCompose.
 unfold PermutationSwap.
 simpl.
 unfold Basics.compose.
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f)).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f)).
-rewrite (MySumF2Same {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (proj1_sig (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q))))) (FMCM f) (fun k : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f)).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f)).
+rewrite (MySumF2Same {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (proj1_sig (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q))))) (FMCM f) (fun k : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig k) (proj1_sig p) with
   | left _ => A q (proj1_sig b k)
   | right _ => match Nat.eq_dec (proj1_sig k) (proj1_sig q) with
     | left _ => A p (proj1_sig b k)
     | right _ => A k (proj1_sig b k)
   end
-end) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig b (match excluded_middle_informative (k = p) with
+end) (fun k : {n : nat | (n < N)} => A k (proj1_sig b (match excluded_middle_informative (k = p) with
   | left _ => q
   | right _ => match excluded_middle_informative (k = q) with
     | left _ => p
@@ -1380,9 +1382,9 @@ apply In_singleton.
 move=> H8 H9 H10 H11.
 reflexivity.
 move=> k H7.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 move=> k H7.
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Full_intro {n : nat | (n < N)} k).
 apply H5.
 apply H5.
 move=> u1 u2 H3 H4 H5.
@@ -1411,7 +1413,7 @@ move=> r H2.
 apply (Full_intro (Permutation N) r).
 Qed.
 
-Lemma DeterminantSwapW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)%nat}), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+Lemma DeterminantSwapW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)}), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => A x q
   | right _ => match Nat.eq_dec (proj1_sig y) (proj1_sig q) with
     | left _ => A x p
@@ -1420,7 +1422,7 @@ Lemma DeterminantSwapW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : 
 end) = Fopp f (Determinant f N A).
 Proof.
 move=> f N A p q H1.
-rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
+rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig p) with
   | left _ => A x q
   | right _ => match Nat.eq_dec (proj1_sig y) (proj1_sig q) with
     | left _ => A x p
@@ -1431,7 +1433,7 @@ rewrite - (DeterminantTrans f N A).
 apply (DeterminantSwapH f N (MTranspose f N N A) p q H1).
 Qed.
 
-Lemma DeterminantDuplicateH : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)%nat}), proj1_sig p <> proj1_sig q -> A p = A q -> Determinant f N A = FO f.
+Lemma DeterminantDuplicateH : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)}), proj1_sig p <> proj1_sig q -> A p = A q -> Determinant f N A = FO f.
 Proof.
 move=> f N A p q H1 H2.
 unfold Determinant.
@@ -1456,7 +1458,7 @@ rewrite (CM_comm_assoc (FPCM f)).
 rewrite H8.
 rewrite (PermutationComposeParity N).
 rewrite (PermutationSwapParity N p q).
-suff: ((MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k))) = (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (proj1_sig b k)))).
+suff: ((MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k))) = (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (proj1_sig b k)))).
 move=> H9.
 rewrite H9.
 elim (PermutationParity N b).
@@ -1470,11 +1472,11 @@ rewrite - (Fmul_add_distr_r f).
 rewrite (Fadd_opp_l f (FI f)).
 rewrite (Fmul_O_l f).
 apply (Fadd_O_r f).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
-rewrite (MySumF2Included {n : nat | (n < N)%nat} (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
+rewrite (MySumF2Included {n : nat | (n < N)} (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 rewrite MySumF2Union.
 rewrite MySumF2Union.
-suff: ((MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (proj1_sig (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q))))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k))) = (MySumF2 {n : nat | (n < N)%nat} (FiniteIntersection {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (Complement {n : nat | (n < N)%nat} (proj1_sig (FiniteUnion {n : nat | (n < N)%nat} (FiniteSingleton {n : nat | (n < N)%nat} p) (FiniteSingleton {n : nat | (n < N)%nat} q))))) (FMCM f) (fun (k : {n : nat | (n < N)%nat}) => A k (proj1_sig b k)))).
+suff: ((MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (proj1_sig (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q))))) (FMCM f) (fun (k : {n : nat | (n < N)}) => A k (proj1_sig (PermutationCompose N b (PermutationSwap N p q)) k))) = (MySumF2 {n : nat | (n < N)} (FiniteIntersection {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (Complement {n : nat | (n < N)} (proj1_sig (FiniteUnion {n : nat | (n < N)} (FiniteSingleton {n : nat | (n < N)} p) (FiniteSingleton {n : nat | (n < N)} q))))) (FMCM f) (fun (k : {n : nat | (n < N)}) => A k (proj1_sig b k)))).
 move=> H9.
 rewrite H9.
 apply (Fmul_eq_compat_r f).
@@ -1544,9 +1546,9 @@ apply H1.
 elim H9.
 reflexivity.
 move=> k H9.
-apply (Full_intro {n : nat | (n < N)%nat}).
+apply (Full_intro {n : nat | (n < N)}).
 move=> k H9.
-apply (Full_intro {n : nat | (n < N)%nat}).
+apply (Full_intro {n : nat | (n < N)}).
 move=> H9.
 apply H1.
 rewrite H9.
@@ -1642,7 +1644,7 @@ move=> r H3.
 apply (Full_intro (Permutation N) r).
 Qed.
 
-Lemma DeterminantDuplicateW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)%nat}), proj1_sig p <> proj1_sig q -> (forall (k : {n : nat | (n < N)%nat}), A k p = A k q) -> Determinant f N A = FO f.
+Lemma DeterminantDuplicateW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)}), proj1_sig p <> proj1_sig q -> (forall (k : {n : nat | (n < N)}), A k p = A k q) -> Determinant f N A = FO f.
 Proof.
 move=> f N A p q H1 H2.
 rewrite - (DeterminantTrans f N A).
@@ -1652,33 +1654,33 @@ move=> k.
 apply (H2 k).
 Qed.
 
-Lemma DeterminantAddTransformH : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)%nat}) (c : FT f), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
+Lemma DeterminantAddTransformH : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)}) (c : FT f), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
   | left _ => Fadd f (A x y) (Fmul f c (A p y))
   | right _ => A x y
 end) = Determinant f N A.
 Proof.
 move=> f N A p q c H1.
-rewrite (DeterminantMultiLinearityHPlus f N A q (fun (k : {n : nat | (n < N)%nat}) => Fmul f c (A p k))).
-suff: ((fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
+rewrite (DeterminantMultiLinearityHPlus f N A q (fun (k : {n : nat | (n < N)}) => Fmul f c (A p k))).
+suff: ((fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
   | left _ => Fmul f c (A p y)
   | right _ => A x y
-end) = (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
-  | left _ => Fmul f c ((fun (x0 y0 : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x0) (proj1_sig q) with
+end) = (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
+  | left _ => Fmul f c ((fun (x0 y0 : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x0) (proj1_sig q) with
     | left _ => A p y0
     | right _ => A x0 y0
   end) x y)
-  | right _ => (fun (x0 y0 : {n0 : nat | (n0 < N)%nat}) => match Nat.eq_dec (proj1_sig x0) (proj1_sig q) with
+  | right _ => (fun (x0 y0 : {n0 : nat | (n0 < N)}) => match Nat.eq_dec (proj1_sig x0) (proj1_sig q) with
     | left _ => A p y0
     | right _ => A x0 y0
   end) x y
 end)).
 move=> H2.
 rewrite H2.
-rewrite (DeterminantMultiLinearityHMult f N (fun x y : {n : nat | (n < N)%nat} => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
+rewrite (DeterminantMultiLinearityHMult f N (fun x y : {n : nat | (n < N)} => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
   | left _ => A p y
   | right _ => A x y
 end) q c).
-rewrite (DeterminantDuplicateH f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
+rewrite (DeterminantDuplicateH f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig q) with
   | left _ => A p y
   | right _ => A x y
 end) p q).
@@ -1713,13 +1715,13 @@ move=> H2.
 reflexivity.
 Qed.
 
-Lemma DeterminantAddTransformW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)%nat}) (c : FT f), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig q) with
+Lemma DeterminantAddTransformW : forall (f : Field) (N : nat) (A : Matrix f N N) (p q : {n : nat | (n < N)}) (c : FT f), proj1_sig p <> proj1_sig q -> Determinant f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig q) with
   | left _ => Fadd f (A x y) (Fmul f c (A x p))
   | right _ => A x y
 end) = Determinant f N A.
 Proof.
 move=> f N A p q c H1.
-rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig q) with
+rewrite - (DeterminantTrans f N (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig q) with
   | left _ => Fadd f (A x y) (Fmul f c (A x p))
   | right _ => A x y
 end)).
@@ -1727,78 +1729,78 @@ rewrite - (DeterminantTrans f N A).
 apply (DeterminantAddTransformH f N (MTranspose f N N A) p q c H1).
 Qed.
 
-Lemma CauchyBinet : forall (f : Field) (N M : nat) (A : Matrix f N M) (B : Matrix f M N), Determinant f N (Mmult f N M N A B) = MySumF2 ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun (r : ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) => forall (p q : {n : nat | (n < N)%nat}), (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) (FPCM f) (fun (r : ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) => Fmul f (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => A x (r y))) (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => B (r x) y))).
+Lemma CauchyBinet : forall (f : Field) (N M : nat) (A : Matrix f N M) (B : Matrix f M N), Determinant f N (Mmult f N M N A B) = MySumF2 ({n : nat | (n < N)} -> {n : nat | (n < M)}) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun (r : ({n : nat | (n < N)} -> {n : nat | (n < M)})) => forall (p q : {n : nat | (n < N)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FPCM f) (fun (r : ({n : nat | (n < N)} -> {n : nat | (n < M)})) => Fmul f (Determinant f N (fun (x y : {n : nat | (n < N)}) => A x (r y))) (Determinant f N (fun (x y : {n : nat | (n < N)}) => B (r x) y))).
 Proof.
 move=> f N M A B.
-suff: (Determinant f N (Mopp f N N (Mmult f N M N A B)) = Determinant f (M + N)%nat (MBlockW f (M + N)%nat M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)))).
+suff: (Determinant f N (Mopp f N N (Mmult f N M N A B)) = Determinant f (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)))).
 move=> H1.
 suff: (Determinant f N (Mmult f N M N A B) = Fmul f (PowF f (Fopp f (FI f)) N) (Determinant f (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))))).
 move=> H2.
 rewrite H2.
 unfold Determinant at 1.
-suff: (forall (p : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (k : {n : nat | (n < M)%nat}), Injective p -> (exists (l : {n : nat | (n < N)%nat}), k = p l) -> {l : {n : nat | (n < N)%nat} | k = p l}).
+suff: (forall (p : {n : nat | (n < N)} -> {n : nat | (n < M)}) (k : {n : nat | (n < M)}), Injective p -> (exists (l : {n : nat | (n < N)}), k = p l) -> {l : {n : nat | (n < N)} | k = p l}).
 move=> H3.
-suff: (forall (l : {n : nat | (n < M)%nat}), (proj1_sig l < M + N)%nat).
+suff: (forall (l : {n : nat | (n < M)}), (proj1_sig l < M + N)).
 move=> H4.
-suff: (forall (l : {n : nat | (n < N)%nat}), (M + proj1_sig l < M + N)%nat).
+suff: (forall (l : {n : nat | (n < N)}), (M + proj1_sig l < M + N)).
 move=> H5.
-suff: (forall (x : (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * ((Permutation N) * (Permutation N)))), Bijective ((fun (x : (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * ((Permutation N) * (Permutation N)))) => match excluded_middle_informative (Injective (fst x)) with
-  | left a => (fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun (s : nat) => (s < M + N)%nat) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) b = fst x l) with
-      | left c => exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) b) a c))))
+suff: (forall (x : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N)))), Bijective ((fun (x : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N)))) => match excluded_middle_informative (Injective (fst x)) with
+  | left a => (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun (s : nat) => (s < M)) (proj1_sig k) b = fst x l) with
+      | left c => exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
     end
   end)
-  | right a => (fun (k : {n : nat | (n < M + N)%nat}) => k)
+  | right a => (fun (k : {n : nat | (n < M + N)}) => k)
 end) x)).
 move=> H6.
-rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * ((Permutation N) * (Permutation N))) (Permutation (M + N)) (fun (x : (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * ((Permutation N) * (Permutation N)))) => exist Bijective (match excluded_middle_informative (Injective (fst x)) with
-  | left a => (fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun (s : nat) => (s < M + N)%nat) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) b = fst x l) with
-      | left c => exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) b) a c))))
+rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N))) (Permutation (M + N)) (fun (x : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N)))) => exist Bijective (match excluded_middle_informative (Injective (fst x)) with
+  | left a => (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun (s : nat) => (s < M)) (proj1_sig k) b = fst x l) with
+      | left c => exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
     end
   end)
-  | right a => (fun (k : {n : nat | (n < M + N)%nat}) => k)
-end) (H6 x)) (FinitePair ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) ((Permutation N) * (Permutation N)) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N)))).
-rewrite (MySumF2O (Permutation (M + N)) (FiniteIntersection (Permutation (M + N)) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N))) (Complement (Permutation (M + N)) (proj1_sig (FiniteIm (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N)) (Permutation (M + N)) (fun x : ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N) => exist Bijective match excluded_middle_informative (Injective (fst x)) with
-  | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst x l) with
-      | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c))))
+  | right a => (fun (k : {n : nat | (n < M + N)}) => k)
+end) (H6 x)) (FinitePair ({n : nat | (n < N)} -> {n : nat | (n < M)}) ((Permutation N) * (Permutation N)) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N)))).
+rewrite (MySumF2O (Permutation (M + N)) (FiniteIntersection (Permutation (M + N)) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N))) (Complement (Permutation (M + N)) (proj1_sig (FiniteIm (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) (Permutation (M + N)) (fun x : ({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N) => exist Bijective match excluded_middle_informative (Injective (fst x)) with
+  | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst x l) with
+      | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
     end
   end
-  | right _ => fun k : {n : nat | (n < M + N)%nat} => k
-end (H6 x)) (FinitePair ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))))))).
-rewrite - (MySumF2BijectiveSame2 (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N)) (Permutation (M + N))).
+  | right _ => fun k : {n : nat | (n < M + N)} => k
+end (H6 x)) (FinitePair ({n : nat | (n < N)} -> {n : nat | (n < M)}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))))))).
+rewrite - (MySumF2BijectiveSame2 (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) (Permutation (M + N))).
 unfold Basics.compose.
-rewrite (MySumF2Pair ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) ((Permutation N) * (Permutation N)) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (FPCM f) (fun (x : ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (y : (Permutation N * Permutation N)) => Fmul f match PermutationParity (M + N) (exist Bijective match excluded_middle_informative (Injective x) with
-    | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-      | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k b)))))
-      | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = x l) with
-        | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => s < M) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c))))
+rewrite (MySumF2Pair ({n : nat | (n < N)} -> {n : nat | (n < M)}) ((Permutation N) * (Permutation N)) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (FPCM f) (fun (x : ({n : nat | (n < N)} -> {n : nat | (n < M)})) (y : (Permutation N * Permutation N)) => Fmul f match PermutationParity (M + N) (exist Bijective match excluded_middle_informative (Injective x) with
+    | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+      | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k b)))))
+      | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = x l) with
+        | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
         | right _ => k
       end
     end
-    | right _ => fun k : {n : nat | (n < M + N)%nat} => k
+    | right _ => fun k : {n : nat | (n < M + N)} => k
   end (H6 (x, y))) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (FMCM f) (fun k : {n : nat | (n < M + N)%nat} => MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig (exist Bijective match excluded_middle_informative (Injective x) with
-  | left a => fun k0 : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k0) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k0 b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k0 b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k0) b = x l) with
-      | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => s < M) (proj1_sig k0) b) a c))))%nat (H5 (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => (s < M)%nat) (proj1_sig k0) b) a c))))
+end (MySumF2 {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (FMCM f) (fun k : {n : nat | (n < M + N)} => MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig (exist Bijective match excluded_middle_informative (Injective x) with
+  | left a => fun k0 : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k0) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k0 b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k0 b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k0) b = x l) with
+      | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => s < M) (proj1_sig k0) b) a c)))) (H5 (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => (s < M)) (proj1_sig k0) b) a c))))
       | right _ => k0
     end
   end
-  | right _ => fun k0 : {n : nat | (n < M + N)%nat} => k0
+  | right _ => fun k0 : {n : nat | (n < M + N)} => k0
 end (H6 (x,y))) k))))).
 rewrite (CM_O_r (FPCM f)).
-apply (FiniteSetInduction ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat))).
+apply (FiniteSetInduction ({n : nat | (n < N)} -> {n : nat | (n < M)}) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q))))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -1809,13 +1811,13 @@ rewrite MySumF2Add.
 rewrite (Fmul_add_distr_l f).
 rewrite H10.
 apply (Fadd_eq_compat_l f).
-suff: (Fmul f (Determinant f N (fun x y : {n : nat | (n < N)%nat} => A x (c y))) (Determinant f N (fun x y : {n : nat | (n < N)%nat} => B (c x) y)) = (MySumF2 ((Permutation N) * (Permutation N)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (FPCM f) (fun PQ : ((Permutation N) * (Permutation N)) => Fmul f (Fmul f match PermutationParity N (fst PQ) with
+suff: (Fmul f (Determinant f N (fun x y : {n : nat | (n < N)} => A x (c y))) (Determinant f N (fun x y : {n : nat | (n < N)} => B (c x) y)) = (MySumF2 ((Permutation N) * (Permutation N)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (FPCM f) (fun PQ : ((Permutation N) * (Permutation N)) => Fmul f (Fmul f match PermutationParity N (fst PQ) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig (fst PQ) k))))) (Fmul f match PermutationParity N (snd PQ) with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig (fst PQ) k))))) (Fmul f match PermutationParity N (snd PQ) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => B (c k) (proj1_sig (snd PQ) k))))))).
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => B (c k) (proj1_sig (snd PQ) k))))))).
 move=> H11.
 rewrite H11.
 apply (FiniteSetInduction (Permutation N * Permutation N) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)))).
@@ -1832,14 +1834,14 @@ apply (Fadd_eq_compat_l f).
 rewrite - (Fmul_assoc f (Fmul f match PermutationParity N (fst d) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig (fst d) k))))) (match PermutationParity N (snd d) with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig (fst d) k))))) (match PermutationParity N (snd d) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end) (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => B (c k) (proj1_sig (snd d) k)))).
+end) (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => B (c k) (proj1_sig (snd d) k)))).
 rewrite (Fmul_comm f (Fmul f match PermutationParity N (fst d) with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig (fst d) k))))) (match PermutationParity N (snd d) with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig (fst d) k))))) (match PermutationParity N (snd d) with
   | ON => Fopp f (FI f)
   | OFF => FI f
 end)).
@@ -1859,14 +1861,14 @@ end match PermutationParity N (fst d) with
 end)).
 rewrite - (Fmul_assoc f (PowF f (Fopp f (FI f)) N)).
 suff: ((Fmul f (PowF f (Fopp f (FI f)) N) match PermutationParity (M + N) (exist Bijective match excluded_middle_informative (Injective c) with
-    | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-      | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b)))))
-      | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-        | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) a c0))))%nat (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c0))))
+    | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+      | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b)))))
+      | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+        | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) a c0)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c0))))
         | right _ => k
       end
     end
-    | right _ => fun k : {n0 : nat | (n0 < M + N)%nat} => k
+    | right _ => fun k : {n0 : nat | (n0 < M + N)} => k
   end (H6 (c, d))) with
   | ON => Fopp f (FI f)
   | OFF => FI f
@@ -1880,29 +1882,29 @@ end)).
 move=> H16.
 rewrite H16.
 apply (Fmul_eq_compat_l f).
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun (k : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig k)%nat))).
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun (k : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), proj1_sig k = proj1_sig (c l))) (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)%nat} (proj1_sig (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)%nat} => (M <= proj1_sig k)%nat)))))).
-rewrite (MySumF2O {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)%nat} (proj1_sig (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)%nat} => (M <= proj1_sig k)%nat))))) (Complement {n : nat | (n < M + N)%nat} (proj1_sig (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)%nat} => exists l : {n : nat | (n < N)%nat}, proj1_sig k = proj1_sig (c l))))))).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)))).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun (k : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), proj1_sig k = proj1_sig (c l))) (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)} (proj1_sig (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => (M <= proj1_sig k))))))).
+rewrite (MySumF2O {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)} (proj1_sig (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => (M <= proj1_sig k)))))) (Complement {n : nat | (n < M + N)} (proj1_sig (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => exists l : {n : nat | (n < N)}, proj1_sig k = proj1_sig (c l))))))).
 rewrite (CM_O_r (FMCM f)).
-suff: ((MySumF2 {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)%nat} => (M <= proj1_sig k)%nat)) (FMCM f) (fun k : {n : nat | (n < M + N)%nat} => MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig (exist Bijective match excluded_middle_informative (Injective c) with
-  | left a => fun k0 : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k0) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k0 b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k0 b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k0) b = c l) with
-      | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k0) b) a c0))))%nat (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k0) b) a c0))))
+suff: ((MySumF2 {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => (M <= proj1_sig k))) (FMCM f) (fun k : {n : nat | (n < M + N)} => MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig (exist Bijective match excluded_middle_informative (Injective c) with
+  | left a => fun k0 : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k0) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k0 b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k0 b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k0) b = c l) with
+      | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k0) b) a c0)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k0) b) a c0))))
       | right _ => k0
     end
   end
-  | right _ => fun k0 : {n0 : nat | (n0 < M + N)%nat} => k0
-end (H6 (c, d))) k))) = (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig (fst d) k))))).
+  | right _ => fun k0 : {n0 : nat | (n0 < M + N)} => k0
+end (H6 (c, d))) k))) = (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig (fst d) k))))).
 move=> H17.
 rewrite H17.
 apply (Fmul_eq_compat_l f).
-suff: ((FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)%nat} => exists l : {n : nat | (n < N)%nat}, proj1_sig k = proj1_sig (c l))) = (FiniteIm {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (fun (l : {n : nat | (n < N)%nat}) => exist (fun (s : nat) => (s < M + N)%nat) (proj1_sig (c l)) (H4 (c l))) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)))).
+suff: ((FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => exists l : {n : nat | (n < N)}, proj1_sig k = proj1_sig (c l))) = (FiniteIm {n : nat | (n < N)} {n : nat | (n < M + N)} (fun (l : {n : nat | (n < N)}) => exist (fun (s : nat) => (s < M + N)) (proj1_sig (c l)) (H4 (c l))) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)))).
 move=> H18.
 rewrite H18.
-rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)} {n : nat | (n < M + N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 unfold Basics.compose.
-apply (MySumF2Same {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f)).
+apply (MySumF2Same {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f)).
 move=> u H19.
 simpl.
 elim (excluded_middle_informative (Injective c)).
@@ -1913,42 +1915,42 @@ move=> H21.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (c u)) H21 (proj2_sig (c u))).
 move=> H21.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21 = c l)).
 move=> H22.
 unfold MBlockW.
 unfold MBlockH.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22))))).
+elim (le_lt_dec M (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))).
 move=> H23.
 elim (le_lt_dec M (proj1_sig (c u))).
 move=> H24.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (c u)) H24 (proj2_sig (c u))).
 move=> H24.
-suff: ((exist (fun n : nat => (n < M)%nat) (proj1_sig (c u)) H24) = c u).
+suff: ((exist (fun n : nat => (n < M)) (proj1_sig (c u)) H24) = c u).
 move=> H25.
 rewrite H25.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22))))%nat (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22))))) H23)) = (proj1_sig (snd d) u)).
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23)) = (proj1_sig (snd d) u)).
 move=> H26.
 rewrite H26.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22))))%nat (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22))))) H23))) (proj1_sig (proj1_sig (snd d) u)) M).
-rewrite ((proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22))))%nat (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22))))) H23))).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23))) (proj1_sig (proj1_sig (snd d) u)) M).
+rewrite ((proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23))).
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22)) = u).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22)) = u).
 move=> H26.
 rewrite H26.
 reflexivity.
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22)).
 apply sig_map.
 reflexivity.
 apply sig_map.
 reflexivity.
 move=> H23.
 apply False_ind.
-apply (lt_not_le (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c u)) H21) H20 H22)))) M H23).
+apply (lt_not_le (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22)))) M H23).
 apply (le_plus_l M).
 move=> H22.
 apply False_ind.
@@ -1983,13 +1985,13 @@ move=> H24.
 elim (le_lt_or_eq (proj1_sig u1) (proj1_sig u2) H24).
 move=> H25.
 apply False_ind.
-apply (lt_irrefl (proj1_sig (exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c0 u1)) (H4 (c0 u1))))).
+apply (lt_irrefl (proj1_sig (exist (fun s : nat => (s < M + N)) (proj1_sig (c0 u1)) (H4 (c0 u1))))).
 rewrite {2} H23.
 apply (H19 u1 u2 H25).
 apply sig_map.
 move=> H24.
 apply False_ind.
-apply (lt_irrefl (proj1_sig (exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c0 u1)) (H4 (c0 u1))))).
+apply (lt_irrefl (proj1_sig (exist (fun s : nat => (s < M + N)) (proj1_sig (c0 u1)) (H4 (c0 u1))))).
 rewrite {1} H23.
 apply (H19 u2 u1 H24).
 apply sig_map.
@@ -2000,8 +2002,8 @@ elim.
 move=> k0 H18 H19.
 elim H18.
 move=> l H20.
-apply (Im_intro {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (Full_set {n : nat | (n < N)%nat}) (fun l : {n : nat | (n < N)%nat} => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c l)) (H4 (c l))) l).
-apply (Full_intro {n : nat | (n < N)%nat} l).
+apply (Im_intro {n : nat | (n < N)} {n : nat | (n < M + N)} (Full_set {n : nat | (n < N)}) (fun l : {n : nat | (n < N)} => exist (fun s : nat => (s < M + N)) (proj1_sig (c l)) (H4 (c l))) l).
+apply (Full_intro {n : nat | (n < N)} l).
 apply sig_map.
 apply H20.
 move=> l.
@@ -2011,11 +2013,11 @@ apply Intersection_intro.
 exists s.
 rewrite H19.
 reflexivity.
-apply (Full_intro {n : nat | (n < M + N)%nat} t).
-suff: ((FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)%nat} => (M <= proj1_sig k)%nat)) = (FiniteIm {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (fun (k : {n : nat | (n < N)%nat}) => exist (fun (l : nat) => (l < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)))).
+apply (Full_intro {n : nat | (n < M + N)} t).
+suff: ((FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => (M <= proj1_sig k))) = (FiniteIm {n : nat | (n < N)} {n : nat | (n < M + N)} (fun (k : {n : nat | (n < N)}) => exist (fun (l : nat) => (l < M + N)) (M + proj1_sig k) (H5 k)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)))).
 move=> H17.
 rewrite H17.
-rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))).
+rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)} {n : nat | (n < M + N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))).
 unfold Basics.compose.
 apply MySumF2Same.
 move=> u H18.
@@ -2031,11 +2033,11 @@ simpl.
 elim (le_lt_dec M (@proj1_sig nat (fun n : nat => lt n M) (c (@proj1_sig (forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N)) (fun f0 : forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N) => @Bijective (@sig nat (fun n : nat => lt n N)) (@sig nat (fun n : nat => lt n N)) f0) (@fst (Permutation N) (Permutation N) d) (@proj1_sig (@sig nat (fun n : nat => lt n N)) (fun y : @sig nat (fun n : nat => lt n N) => @eq nat (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) y)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) u))) (blockdividesub M N (@exist nat (fun l : nat => lt l (Init.Nat.add M N)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) u)) (H5 u)) H20)))))).
 move=> H21.
 apply False_ind.
-apply (lt_not_le (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u)%nat (H5 u)) H20))))) M (proj2_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u)%nat (H5 u)) H20))))) H21).
+apply (lt_not_le (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) M (proj2_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) H21).
 move=> H21.
-suff: ((proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u)%nat (H5 u)) H20)) = u).
+suff: ((proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20)) = u).
 move=> H22.
-suff: ((exist (fun n : nat => (n < M)%nat) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u)%nat (H5 u)) H20))))) H21) = (c (proj1_sig (fst d) u))).
+suff: ((exist (fun n : nat => (n < M)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) H21) = (c (proj1_sig (fst d) u))).
 move=> H23.
 rewrite H23.
 rewrite H22.
@@ -2045,11 +2047,11 @@ simpl.
 rewrite H22.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u)%nat (H5 u)) H20))) (proj1_sig u) M).
-apply (proj2_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u)%nat (H5 u)) H20)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))) (proj1_sig u) M).
+apply (proj2_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20)).
 move=> H20.
 apply False_ind.
-apply (lt_not_le (M + proj1_sig u)%nat M H20).
+apply (lt_not_le (M + proj1_sig u) M H20).
 apply le_plus_l.
 move=> H19.
 apply False_ind.
@@ -2074,7 +2076,7 @@ apply (H20 k2 k1 H23).
 move=> u1 u2 H18 H19 H20.
 apply sig_map.
 apply (plus_reg_l (proj1_sig u1) (proj1_sig u2) M).
-suff: ((M + proj1_sig u1)%nat = proj1_sig (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig u1)%nat (H5 u1))).
+suff: ((M + proj1_sig u1) = proj1_sig (exist (fun l : nat => (l < M + N)) (M + proj1_sig u1) (H5 u1))).
 move=> H21.
 rewrite H21.
 rewrite H20.
@@ -2086,15 +2088,15 @@ apply conj.
 move=> k.
 elim.
 move=> k0 H17 H18.
-suff: (proj1_sig k0 - M < N)%nat.
+suff: (proj1_sig k0 - M < N).
 move=> H19.
-apply (Im_intro {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (Full_set {n : nat | (n < N)%nat}) (fun (k1 : {n : nat | (n < N)%nat}) => exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig k1)%nat (H5 k1)) (exist (fun (n : nat) => (n < N)%nat) (proj1_sig k0 - M)%nat H19)).
-apply (Full_intro {n : nat | (n < N)%nat}).
+apply (Im_intro {n : nat | (n < N)} {n : nat | (n < M + N)} (Full_set {n : nat | (n < N)}) (fun (k1 : {n : nat | (n < N)}) => exist (fun l : nat => (l < M + N)) (M + proj1_sig k1) (H5 k1)) (exist (fun (n : nat) => (n < N)) (proj1_sig k0 - M) H19)).
+apply (Full_intro {n : nat | (n < N)}).
 apply sig_map.
 simpl.
 rewrite (le_plus_minus_r M (proj1_sig k0) H17).
 reflexivity.
-apply (plus_lt_reg_l (proj1_sig k0 - M)%nat N M).
+apply (plus_lt_reg_l (proj1_sig k0 - M) N M).
 rewrite (le_plus_minus_r M (proj1_sig k0) H17).
 apply (proj2_sig k0).
 move=> k.
@@ -2103,7 +2105,7 @@ move=> s H17 t H18.
 rewrite H18.
 apply Intersection_intro.
 apply (le_plus_l M (proj1_sig s)).
-apply (Full_intro {n : nat | (n < M + N)%nat}).
+apply (Full_intro {n : nat | (n < M + N)}).
 move=> u H17.
 unfold MBlockW.
 unfold MBlockH.
@@ -2119,11 +2121,11 @@ apply False_ind.
 apply H21.
 apply Intersection_intro.
 apply H23.
-apply (Full_intro {n : nat | (n < M + N)%nat} k1).
+apply (Full_intro {n : nat | (n < M + N)} k1).
 move=> H19.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig u) H19 = c l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig u) H19 = c l)).
 move=> H20.
-suff: (~ exists (l : {n : nat | (n < N)%nat}), (proj1_sig u) = proj1_sig (c l)).
+suff: (~ exists (l : {n : nat | (n < N)}), (proj1_sig u) = proj1_sig (c l)).
 move=> H21.
 apply False_ind.
 apply H21.
@@ -2137,7 +2139,7 @@ move=> u0 H21 H22 H23.
 apply H21.
 apply Intersection_intro.
 apply H23.
-apply (Full_intro {n : nat | (n < M + N)%nat} u0).
+apply (Full_intro {n : nat | (n < M + N)} u0).
 move=> H20.
 elim (le_lt_dec M (proj1_sig u)).
 move=> H21.
@@ -2145,7 +2147,7 @@ apply False_ind.
 apply (lt_not_le (proj1_sig u) M H19 H21).
 move=> H21.
 unfold MI.
-elim (Nat.eq_dec (proj1_sig (exist (fun n : nat => (n < M)%nat) (proj1_sig u) H19)) (proj1_sig (exist (fun n : nat => (n < M)%nat) (proj1_sig u) H21))).
+elim (Nat.eq_dec (proj1_sig (exist (fun n : nat => (n < M)) (proj1_sig u) H19)) (proj1_sig (exist (fun n : nat => (n < M)) (proj1_sig u) H21))).
 move=> H22.
 reflexivity.
 move=> H22.
@@ -2188,84 +2190,84 @@ elim H17.
 move=> l H20.
 rewrite H20.
 apply (proj2_sig (c l)).
-apply (Full_intro {n : nat | (n < M + N)%nat} k0).
+apply (Full_intro {n : nat | (n < M + N)} k0).
 move=> k H17.
-apply (Full_intro {n : nat | (n < M + N)%nat} k).
-suff: (forall (N1 N2 : nat) (p : {n : nat | (n < N1)%nat} -> {n : nat | (n < N2)%nat}) (k : {n : nat | (n < N2)%nat}), Injective p -> (exists l : {n : nat | (n < N1)%nat}, k = p l) -> {l : {n : nat | (n < N1)%nat} | k = p l}).
+apply (Full_intro {n : nat | (n < M + N)} k).
+suff: (forall (N1 N2 : nat) (p : {n : nat | (n < N1)} -> {n : nat | (n < N2)}) (k : {n : nat | (n < N2)}), Injective p -> (exists l : {n : nat | (n < N1)}, k = p l) -> {l : {n : nat | (n < N1)} | k = p l}).
 move=> H16.
-suff: (forall (N1 N2 : nat) (f : {n : nat | (n < N1)%nat} -> {n : nat | (n < N2)%nat}) (P : Permutation N1) (H : Injective f), Bijective (fun (k : {n : nat | (n < N2)%nat}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, k = f l) with
+suff: (forall (N1 N2 : nat) (f : {n : nat | (n < N1)} -> {n : nat | (n < N2)}) (P : Permutation N1) (H : Injective f), Bijective (fun (k : {n : nat | (n < N2)}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)}, k = f l) with
   | left H2 => f (proj1_sig P (proj1_sig (H16 N1 N2 f k H H2)))
   | right _ => k
 end)).
 move=> H17.
-suff: (forall (N1 N2 : nat) (f : {n : nat | (n < N1)%nat} -> {n : nat | (n < N2)%nat}) (P : Permutation N1) (H : Injective f), (forall (p q : {n : nat | (n < N1)%nat}), (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (f p) < proj1_sig (f q))%nat) -> PermutationParity N1 P = PermutationParity N2 (exist Bijective (fun (k : {n : nat | (n < N2)%nat}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, k = f l) with
+suff: (forall (N1 N2 : nat) (f : {n : nat | (n < N1)} -> {n : nat | (n < N2)}) (P : Permutation N1) (H : Injective f), (forall (p q : {n : nat | (n < N1)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (f p) < proj1_sig (f q))) -> PermutationParity N1 P = PermutationParity N2 (exist Bijective (fun (k : {n : nat | (n < N2)}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)}, k = f l) with
   | left H2 => f (proj1_sig P (proj1_sig (H16 N1 N2 f k H H2)))
   | right _ => k
 end) (H17 N1 N2 f P H))).
 move=> H18.
-suff: (forall (N1 : nat) (co : nat) (P : Permutation N1), (forall (k : {n : nat | (n < N1)%nat}), proj1_sig P (proj1_sig P k) = k) -> cardinal {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) co -> Fmul f (PowF f (Fopp f (FI f)) co) (match PermutationParity N1 P with
+suff: (forall (N1 : nat) (co : nat) (P : Permutation N1), (forall (k : {n : nat | (n < N1)}), proj1_sig P (proj1_sig P k) = k) -> cardinal {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) co -> Fmul f (PowF f (Fopp f (FI f)) co) (match PermutationParity N1 P with
   | ON => Fopp f (FI f)
   | OFF => FI f
 end) = FI f).
 move=> H19.
 suff: (Injective c).
 move=> H20.
-suff: (Bijective (fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-    | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H20 c0)))
+suff: (Bijective (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+    | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
 end)).
 move=> H21.
-suff: (Injective (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k)%nat (H5 k))).
+suff: (Injective (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k) (H5 k))).
 move=> H22.
-suff: (Injective (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (c k)) (H4 (c k)))).
+suff: (Injective (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (proj1_sig (c k)) (H4 (c k)))).
 move=> H23.
 suff: ((exist Bijective match excluded_middle_informative (Injective c) with
-  | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-      | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) a c0))))%nat (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c0))))
+  | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+      | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) a c0)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c0))))
       | right _ => k
     end
   end
-  | right _ => fun k : {n0 : nat | (n0 < M + N)%nat} => k
-end (H6 (c, d))) = PermutationCompose (M + N)%nat (exist Bijective (fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-    | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H20 c0)))
+  | right _ => fun k : {n0 : nat | (n0 < M + N)} => k
+end (H6 (c, d))) = PermutationCompose (M + N) (exist Bijective (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+    | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
-end) H21) (PermutationCompose (M + N)%nat (exist Bijective (fun k : {n : nat | (n < M + N)%nat} => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, k = (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) l) with
-  | left H2 => (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (proj1_sig (fst d) (proj1_sig (H16 N (M + N)%nat (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) k H22 H2)))
+end) H21) (PermutationCompose (M + N) (exist Bijective (fun k : {n : nat | (n < M + N)} => match excluded_middle_informative (exists l : {n : nat | (n < N)}, k = (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k) (H5 k)) l) with
+  | left H2 => (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k) (H5 k)) (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k) (H5 k)) k H22 H2)))
   | right _ => k
-end) (H17 N (M + N)%nat (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (fst d) H22)) (exist Bijective (fun k : {n : nat | (n < M + N)%nat} => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, k = (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (c k)) (H4 (c k))) l) with
-  | left H2 => (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (c k)) (H4 (c k))) (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (c k)) (H4 (c k))) k H23 H2)))
+end) (H17 N (M + N) (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k) (H5 k)) (fst d) H22)) (exist Bijective (fun k : {n : nat | (n < M + N)} => match excluded_middle_informative (exists l : {n : nat | (n < N)}, k = (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (proj1_sig (c k)) (H4 (c k))) l) with
+  | left H2 => (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (proj1_sig (c k)) (H4 (c k))) (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (proj1_sig (c k)) (H4 (c k))) k H23 H2)))
   | right _ => k
-end) (H17 N (M + N)%nat (fun (k : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (c k)) (H4 (c k))) (snd d) H23)))).
+end) (H17 N (M + N) (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (proj1_sig (c k)) (H4 (c k))) (snd d) H23)))).
 move=> H24.
 rewrite H24.
-rewrite (PermutationComposeParity (M + N)%nat).
-suff: (forall (X Y : Permutation (M + N)%nat), match ParityXOR (PermutationParity (M + N)%nat X) (PermutationParity (M + N)%nat Y) with
+rewrite (PermutationComposeParity (M + N)).
+suff: (forall (X Y : Permutation (M + N)), match ParityXOR (PermutationParity (M + N) X) (PermutationParity (M + N) Y) with
   | OFF => FI f
   | ON => Fopp f (FI f)
-end = Fmul f match PermutationParity (M + N)%nat X with
+end = Fmul f match PermutationParity (M + N) X with
   | OFF => FI f
   | ON => Fopp f (FI f)
-end match PermutationParity (M + N)%nat Y with
+end match PermutationParity (M + N) Y with
   | OFF => FI f
   | ON => Fopp f (FI f)
 end).
 move=> H25.
 rewrite H25.
 rewrite - (Fmul_assoc f).
-rewrite (H19 (M + N)%nat N).
+rewrite (H19 (M + N) N).
 rewrite (Fmul_I_l f).
-rewrite (PermutationComposeParity (M + N)%nat).
+rewrite (PermutationComposeParity (M + N)).
 rewrite H25.
-rewrite - (H18 N (M + N)%nat (fun (k : {n : nat | (n < N)%nat}) => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (fst d) H22).
-rewrite - (H18 N (M + N)%nat (fun k : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k)) (H4 (c k))) (snd d) H23).
+rewrite - (H18 N (M + N) (fun (k : {n : nat | (n < N)}) => exist (fun n : nat => (n < M + N)) (M + proj1_sig k) (H5 k)) (fst d) H22).
+rewrite - (H18 N (M + N) (fun k : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k)) (H4 (c k))) (snd d) H23).
 apply (Fmul_comm f).
 elim H8.
 move=> c0 H26 H27.
@@ -2282,16 +2284,16 @@ move=> H27.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27 (proj2_sig (c (proj1_sig (blockdividesub M N k H26))))).
 move=> H27.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27 = c l)).
 move=> H28.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27) H20 H28)) = (proj1_sig (blockdividesub M N k H26))).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27) H20 H28)) = (proj1_sig (blockdividesub M N k H26))).
 move=> H29.
 rewrite H29.
 apply (proj2_sig (blockdividesub M N k H26)).
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27) H20 H28)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27) H20 H28)).
 apply sig_map.
 reflexivity.
 move=> H28.
@@ -2301,10 +2303,10 @@ exists (proj1_sig (blockdividesub M N k H26)).
 apply sig_map.
 reflexivity.
 move=> H26.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) H26 = c l)).
 move=> H27.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26) H20 H27)))%nat).
+elim (le_lt_dec M (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))).
 move=> H28.
 apply sig_map.
 simpl.
@@ -2313,20 +2315,20 @@ move=> l H29.
 suff: (proj1_sig k = proj1_sig (c l)).
 move=> H30.
 rewrite {7} H30.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26) H20 H27)))) H28)) = l).
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28)) = l).
 move=> H31.
 rewrite H31.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26) H20 H27)))) H28))) (proj1_sig l) M).
-rewrite ((proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26) H20 H27)))) H28))).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28))) (proj1_sig l) M).
+rewrite ((proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28))).
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26) H20 H27)) = l).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)) = l).
 move=> H31.
 rewrite H31.
 reflexivity.
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26) H20 H27)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)).
 apply sig_map.
 simpl.
 apply H30.
@@ -2334,7 +2336,7 @@ rewrite - H29.
 reflexivity.
 move=> H28.
 apply False_ind.
-apply (lt_not_le (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27)))%nat M H28).
+apply (lt_not_le (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) M H28).
 apply le_plus_l.
 move=> H27.
 elim (le_lt_dec M (proj1_sig k)).
@@ -2342,7 +2344,7 @@ move=> H28.
 apply False_ind.
 apply (le_not_lt M (proj1_sig k) H28 H26).
 move=> H28.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) H28 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) H28 = c l)).
 move=> H29.
 apply False_ind.
 apply H27.
@@ -2357,24 +2359,24 @@ apply proof_irrelevance.
 move=> H29.
 reflexivity.
 simpl.
-suff: ((fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig match le_lt_dec M (proj1_sig k) with
+suff: ((fun (k : {n : nat | (n < M + N)}) => (proj1_sig match le_lt_dec M (proj1_sig k) with
   | left b => exist (fun s : nat => s < M + N) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | n < N}, exist (fun s : nat => s < M) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => s < M + N) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
-end < proj1_sig k)%nat) = (fun (k : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig k)%nat)).
+end < proj1_sig k)) = (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k))).
 move=> H26.
 rewrite H26.
-apply (CardinalSigSame {n : nat | (n < M + N)%nat}).
-apply (CountCardinalBijective {t : {n : nat | (n < M + N)%nat} | (M <= proj1_sig t)%nat}).
-exists (fun (k : {n : nat | (n < N)%nat}) => (exist (fun (t : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig t)%nat) (exist (fun (l : nat) => (l < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (le_plus_l M (proj1_sig k)))).
-exists (fun (k : {t : {n : nat | (n < M + N)%nat} | (M <= proj1_sig t)%nat}) => proj1_sig (blockdividesub M N (proj1_sig k) (proj2_sig k))).
+apply (CardinalSigSame {n : nat | (n < M + N)}).
+apply (CountCardinalBijective {t : {n : nat | (n < M + N)} | (M <= proj1_sig t)}).
+exists (fun (k : {n : nat | (n < N)}) => (exist (fun (t : {n : nat | (n < M + N)}) => (M <= proj1_sig t)) (exist (fun (l : nat) => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))).
+exists (fun (k : {t : {n : nat | (n < M + N)} | (M <= proj1_sig t)}) => proj1_sig (blockdividesub M N (proj1_sig k) (proj2_sig k))).
 apply conj.
 move=> k.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)%nat} => (M <= proj1_sig t)%nat) (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)%nat} => (M <= proj1_sig t)%nat) (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (le_plus_l M (proj1_sig k))))))) (proj1_sig k) M).
-rewrite (proj2_sig (blockdividesub M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)%nat} => (M <= proj1_sig t)%nat) (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)%nat} => (M <= proj1_sig t)%nat) (exist (fun l : nat => (l < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) (le_plus_l M (proj1_sig k)))))).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k))))))) (proj1_sig k) M).
+rewrite (proj2_sig (blockdividesub M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))))).
 reflexivity.
 move=> y.
 apply sig_map.
@@ -2389,13 +2391,13 @@ elim (le_lt_dec M (proj1_sig k)).
 move=> H26 H27.
 apply H26.
 move=> H26.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) H26 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) H26 = c l)).
 simpl.
 move=> H27 H28.
 apply False_ind.
 apply (lt_irrefl M).
 apply (lt_trans M (proj1_sig k) M).
-apply (le_trans (S M) (S (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27)))%nat) (proj1_sig k)).
+apply (le_trans (S M) (S (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27)))) (proj1_sig k)).
 apply le_n_S.
 apply le_plus_l.
 apply H28.
@@ -2434,7 +2436,7 @@ apply functional_extensionality.
 move=> k.
 elim (le_lt_dec M (proj1_sig k)).
 move=> H25.
-elim (excluded_middle_informative (exists l0 : {n : nat | (n < N)%nat}, k = exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c l0)) (H4 (c l0)))).
+elim (excluded_middle_informative (exists l0 : {n : nat | (n < N)}, k = exist (fun n : nat => (n < M + N)) (proj1_sig (c l0)) (H4 (c l0)))).
 move=> H26.
 apply False_ind.
 apply (le_not_lt M (proj1_sig k) H25).
@@ -2443,99 +2445,99 @@ move=> s H27.
 rewrite H27.
 apply (proj2_sig (c s)).
 move=> H26.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, k = exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig l)%nat (H5 l))).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, k = exist (fun n : nat => (n < M + N)) (M + proj1_sig l) (H5 l))).
 move=> H27.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27))))).
+elim (le_lt_dec M (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))).
 move=> H28.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (fst d) (proj1_sig (blockdividesub M N k H25))) = (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27))))%nat (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27))))) H28))).
+suff: ((proj1_sig (fst d) (proj1_sig (blockdividesub M N k H25))) = (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28))).
 move=> H29.
 rewrite H29.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (fst d) (proj1_sig (blockdividesub M N k H25)))) (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27))))%nat (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27))))) H28))) M).
-rewrite (proj2_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27))))%nat (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27))))) H28)).
+apply (plus_reg_l (proj1_sig (proj1_sig (fst d) (proj1_sig (blockdividesub M N k H25)))) (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28))) M).
+rewrite (proj2_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28)).
 simpl.
-suff: ((proj1_sig (blockdividesub M N k H25)) = (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27))).
+suff: ((proj1_sig (blockdividesub M N k H25)) = (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))).
 move=> H29.
 rewrite H29.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N k H25))) (proj1_sig (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27))) M).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N k H25))) (proj1_sig (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))) M).
 rewrite (proj2_sig (blockdividesub M N k H25)).
-rewrite {1} (proj2_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k0)%nat (H5 k0)) k H22 H27)).
+rewrite {1} (proj2_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27)).
 reflexivity.
 move=> H28.
 apply False_ind.
-apply (lt_not_le (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27))))%nat M H28).
+apply (lt_not_le (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) M H28).
 apply le_plus_l.
 move=> H27.
 apply False_ind.
 apply H27.
-suff: (proj1_sig k - M < N)%nat.
+suff: (proj1_sig k - M < N).
 move=> H28.
-exists (exist (fun (n : nat) => (n < N)%nat) (proj1_sig k - M)%nat H28).
+exists (exist (fun (n : nat) => (n < N)) (proj1_sig k - M) H28).
 apply sig_map.
 simpl.
 rewrite (le_plus_minus_r M (proj1_sig k) H25).
 reflexivity.
-apply (plus_lt_reg_l (proj1_sig k - M)%nat N M).
+apply (plus_lt_reg_l (proj1_sig k - M) N M).
 rewrite (le_plus_minus_r M (proj1_sig k) H25).
 apply (proj2_sig k).
 move=> H25.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig k) H25 = c l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig k) H25 = c l)).
 move=> H26.
-elim (excluded_middle_informative (exists (l0 : {n : nat | (n < N)%nat}), k = exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c l0)) (H4 (c l0)))).
+elim (excluded_middle_informative (exists (l0 : {n : nat | (n < N)}), k = exist (fun n : nat => (n < M + N)) (proj1_sig (c l0)) (H4 (c l0)))).
 move=> H27.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) (H4 (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) = exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig l)%nat (H5 l))).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun n : nat => (n < M + N)) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) (H4 (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) = exist (fun n : nat => (n < M + N)) (M + proj1_sig l) (H5 l))).
 move=> H28.
 apply False_ind.
 elim H28.
 move=> l H29.
 apply (lt_irrefl M).
-apply (le_trans (S M) (S (M + proj1_sig l)%nat) M).
+apply (le_trans (S M) (S (M + proj1_sig l)) M).
 apply le_n_S.
 apply le_plus_l.
-suff: ((M + proj1_sig l)%nat = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig l)%nat (H5 l))).
+suff: ((M + proj1_sig l) = proj1_sig (exist (fun n : nat => (n < M + N)) (M + proj1_sig l) (H5 l))).
 move=> H30.
 rewrite H30.
 rewrite - H29.
-apply (proj2_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))).
+apply (proj2_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))).
 reflexivity.
 move=> H28.
 simpl.
-elim (le_lt_dec M (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))))).
+elim (le_lt_dec M (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))))).
 move=> H29.
 apply False_ind.
-apply (le_not_lt M (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))))%nat H29 (proj2_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))))%nat).
+apply (le_not_lt M (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29 (proj2_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))))).
 move=> H29.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29 = c l)).
 move=> H30.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29) H20 H30))%nat = (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29) H20 H30)) = (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))).
 move=> H31.
 rewrite H31.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H25) H24 H26))%nat = (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))%nat).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H25) H24 H26)) = (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))).
 move=> H32.
 rewrite H32.
 reflexivity.
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H25) H24 H26))%nat.
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H25) H24 H26)).
 apply sig_map.
 simpl.
-rewrite {1} (proj2_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))%nat.
+rewrite {1} (proj2_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)).
 reflexivity.
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29) H20 H30)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))))) H29) H20 H30)).
 apply sig_map.
 reflexivity.
 move=> H30.
 apply False_ind.
 apply H30.
-exists (proj1_sig (snd d) (proj1_sig (H16 N (M + N)%nat (fun k0 : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27)))%nat.
+exists (proj1_sig (snd d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (proj1_sig (c k0)) (H4 (c k0))) k H23 H27))).
 apply sig_map.
 reflexivity.
 move=> H27.
@@ -2548,7 +2550,7 @@ rewrite - H28.
 apply sig_map.
 reflexivity.
 move=> H26.
-elim (excluded_middle_informative (exists l0 : {n : nat | (n < N)%nat}, k = exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c l0)) (H4 (c l0)))).
+elim (excluded_middle_informative (exists l0 : {n : nat | (n < N)}, k = exist (fun n : nat => (n < M + N)) (proj1_sig (c l0)) (H4 (c l0)))).
 move=> H27.
 apply False_ind.
 apply H26.
@@ -2560,7 +2562,7 @@ simpl.
 rewrite H28.
 reflexivity.
 move=> H27.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, k = exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig l)%nat (H5 l))).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, k = exist (fun n : nat => (n < M + N)) (M + proj1_sig l) (H5 l))).
 move=> H28.
 apply False_ind.
 elim H28.
@@ -2577,7 +2579,7 @@ move=> H29.
 apply False_ind.
 apply (le_not_lt M (proj1_sig k) H29 H25).
 move=> H29.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) H29 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) H29 = c l)).
 move=> H30.
 apply False_ind.
 apply H26.
@@ -2597,7 +2599,7 @@ apply (H24 H20).
 move=> k1 k2 H23.
 apply H20.
 apply sig_map.
-suff: (proj1_sig (c k1) = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (c k1)) (H4 (c k1)))).
+suff: (proj1_sig (c k1) = proj1_sig (exist (fun n : nat => (n < M + N)) (proj1_sig (c k1)) (H4 (c k1)))).
 move=> H24.
 rewrite H24.
 rewrite H23.
@@ -2606,29 +2608,29 @@ reflexivity.
 move=> k1 k2 H22.
 apply sig_map.
 apply (plus_reg_l (proj1_sig k1) (proj1_sig k2) M).
-suff: ((M + proj1_sig k1)%nat = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k1)%nat (H5 k1))).
+suff: ((M + proj1_sig k1) = proj1_sig (exist (fun n : nat => (n < M + N)) (M + proj1_sig k1) (H5 k1))).
 move=> H23.
 rewrite H23.
 rewrite H22.
 reflexivity.
 reflexivity.
-exists (fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-    | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H20 c0)))
+exists (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+    | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
 end).
-suff: (forall (x : {n : nat | (n < M + N)%nat}), Basics.compose (fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-    | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H20 c0)))
+suff: (forall (x : {n : nat | (n < M + N)}), Basics.compose (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+    | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
-end) (fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = c l) with
-    | left c0 => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H20 c0)))
+end) (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
+    | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
 end) x = x).
@@ -2646,16 +2648,16 @@ move=> H22.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22 (proj2_sig (c (proj1_sig (blockdividesub M N k H21))))).
 move=> H22.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22 = c l)).
 move=> H23.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22) H20 H23)) = (proj1_sig (blockdividesub M N k H21)))%nat.
+suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22) H20 H23)) = (proj1_sig (blockdividesub M N k H21))).
 move=> H24.
 rewrite H24.
 apply (proj2_sig (blockdividesub M N k H21)).
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22) H20 H23)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22) H20 H23)).
 apply sig_map.
 reflexivity.
 move=> H23.
@@ -2665,25 +2667,25 @@ exists (proj1_sig (blockdividesub M N k H21)).
 apply sig_map.
 reflexivity.
 move=> H21.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) H21 = c l)).
 move=> H22.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21) H20 H22)))).
+elim (le_lt_dec M (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))).
 move=> H23.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21) H20 H22)))) H23)) = (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22)))%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23)) = (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))).
 move=> H24.
 rewrite H24.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21) H20 H22)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)).
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21) H20 H22)))) H23))) (proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21) H20 H22))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22)))%nat (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H21) H20 H22)))) H23)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23))) (proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22))) M).
+apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23)).
 move=> H23.
 apply False_ind.
 apply (lt_irrefl M).
-apply (le_trans (S M) (S (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22)))) M)%nat.
+apply (le_trans (S M) (S (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22)))) M).
 apply le_n_S.
 apply le_plus_l.
 apply H23.
@@ -2693,7 +2695,7 @@ move=> H23.
 apply False_ind.
 apply (le_not_lt M (proj1_sig k) H23 H21).
 move=> H23.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) H23 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) H23 = c l)).
 move=> H24.
 apply False_ind.
 apply H22.
@@ -2739,21 +2741,21 @@ move=> H21.
 elim (le_lt_or_eq (proj1_sig (proj1_sig P k)) (proj1_sig k) H21).
 move=> H22.
 apply False_ind.
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) k).
-rewrite (cardinal_elim {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) O H20).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) k).
+rewrite (cardinal_elim {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) O H20).
 elim.
 apply H22.
 apply.
 move=> H21.
 apply False_ind.
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) (proj1_sig P k)).
-rewrite (cardinal_elim {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) O H20).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) (proj1_sig P k)).
+rewrite (cardinal_elim {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) O H20).
 elim.
 unfold In.
 rewrite (H19 k).
 apply H21.
 move=> n H19 P H20 H21.
-elim (cardinal_invert {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) (S n) H21).
+elim (cardinal_invert {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) (S n) H21).
 move=> W.
 elim.
 move=> w H22.
@@ -2801,15 +2803,15 @@ move=> H26.
 apply False_ind.
 apply (lt_irrefl (proj1_sig (proj1_sig P w))).
 rewrite {2} H26.
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) w).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) w).
 apply.
 rewrite (proj1 H22).
 right.
-apply (In_singleton {n : nat | (n < N1)%nat} w).
+apply (In_singleton {n : nat | (n < N1)} w).
 move=> H26.
 elim (excluded_middle_informative (proj1_sig P w = proj1_sig P w)).
 move=> H27.
-apply (BijInj {n : nat | (n < N1)%nat} {n : nat | (n < N1)%nat} (proj1_sig P) (proj2_sig P)).
+apply (BijInj {n : nat | (n < N1)} {n : nat | (n < N1)} (proj1_sig P) (proj2_sig P)).
 rewrite H25.
 reflexivity.
 move=> H27.
@@ -2828,10 +2830,10 @@ move=> H26.
 elim (excluded_middle_informative (proj1_sig P (proj1_sig P k) = proj1_sig P w)).
 move=> H27.
 apply False_ind.
-apply (H24 (BijInj {n : nat | (n < N1)%nat} {n : nat | (n < N1)%nat} (proj1_sig P) (proj2_sig P) (proj1_sig P k) w H27)).
+apply (H24 (BijInj {n : nat | (n < N1)} {n : nat | (n < N1)} (proj1_sig P) (proj2_sig P) (proj1_sig P k) w H27)).
 move=> H27.
 apply (H20 k).
-suff: ((fun (k : {n0 : nat | (n0 < N1)%nat}) => (proj1_sig (proj1_sig (PermutationCompose N1 (PermutationSwap N1 w (proj1_sig P w)) P) k) < proj1_sig k)%nat) = W).
+suff: ((fun (k : {n0 : nat | (n0 < N1)}) => (proj1_sig (proj1_sig (PermutationCompose N1 (PermutationSwap N1 w (proj1_sig P w)) P) k) < proj1_sig k)) = W).
 move=> H24.
 rewrite H24.
 apply (proj2 (proj2 H22)).
@@ -2859,10 +2861,10 @@ suff: (u = w).
 move=> H27.
 rewrite {1} H27.
 apply H26.
-apply (BijInj {n : nat | (n < N1)%nat} {n : nat | (n < N1)%nat} (proj1_sig P) (proj2_sig P) u w H25).
+apply (BijInj {n : nat | (n < N1)} {n : nat | (n < N1)} (proj1_sig P) (proj2_sig P) u w H25).
 move=> H25 H26.
 suff: (proj1_sig P u <> proj1_sig P w).
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) u).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) u).
 rewrite (proj1 H22).
 elim.
 move=> u0 H27 H28.
@@ -2888,16 +2890,16 @@ apply (lt_irrefl (proj1_sig w)).
 apply (lt_trans (proj1_sig w) (proj1_sig (proj1_sig P w)) (proj1_sig w)).
 rewrite - H25.
 rewrite (H20 u).
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) u).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) u).
 apply.
 rewrite (proj1 H22).
 left.
 apply H24.
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) w).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) w).
 apply.
 rewrite (proj1 H22).
 right.
-apply (In_singleton {n : nat | (n < N1)%nat} w).
+apply (In_singleton {n : nat | (n < N1)} w).
 move=> H25.
 elim (excluded_middle_informative (proj1_sig P u = proj1_sig P w)).
 move=> H26.
@@ -2907,9 +2909,9 @@ suff: (u = w).
 move=> H27.
 rewrite - H27.
 apply H24.
-apply (BijInj {n : nat | (n < N1)%nat} {n : nat | (n < N1)%nat} (proj1_sig P) (proj2_sig P) u w H26).
+apply (BijInj {n : nat | (n < N1)} {n : nat | (n < N1)} (proj1_sig P) (proj2_sig P) u w H26).
 move=> H26.
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) u).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) u).
 apply.
 rewrite (proj1 H22).
 left.
@@ -2923,12 +2925,12 @@ reflexivity.
 move=> H23.
 apply (lt_irrefl (proj1_sig w)).
 rewrite {1} H23.
-suff: (In {n : nat | (n < N1)%nat} (fun (k : {n : nat | (n < N1)%nat}) => (proj1_sig (proj1_sig P k) < proj1_sig k)%nat) w).
+suff: (In {n : nat | (n < N1)} (fun (k : {n : nat | (n < N1)}) => (proj1_sig (proj1_sig P k) < proj1_sig k)) w).
 apply.
 rewrite (proj1 H22).
 right.
-apply (In_singleton {n : nat | (n < N1)%nat} w).
-suff: (forall (N1 N2 : nat) (f : {n : nat | (n < N1)%nat} -> {n : nat | (n < N2)%nat}) (H : Injective f), (forall (p q : {n : nat | (n < N1)%nat}), (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (f p) < proj1_sig (f q))%nat) -> forall (m : nat) (P : Permutation N1), (m <= N1)%nat -> (forall (k : {n : nat | (n < N1)%nat}), (proj1_sig k >= m)%nat -> proj1_sig P k = k) -> PermutationParity N1 P = PermutationParity N2 (exist Bijective (fun (k : {n : nat | (n < N2)%nat}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, k = f l) with
+apply (In_singleton {n : nat | (n < N1)} w).
+suff: (forall (N1 N2 : nat) (f : {n : nat | (n < N1)} -> {n : nat | (n < N2)}) (H : Injective f), (forall (p q : {n : nat | (n < N1)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (f p) < proj1_sig (f q))) -> forall (m : nat) (P : Permutation N1), (m <= N1) -> (forall (k : {n : nat | (n < N1)}), (proj1_sig k >= m) -> proj1_sig P k = k) -> PermutationParity N1 P = PermutationParity N2 (exist Bijective (fun (k : {n : nat | (n < N2)}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)}, k = f l) with
   | left H0 => f (proj1_sig P (proj1_sig (H16 N1 N2 f k H H0)))
   | right _ => k
 end) (H17 N1 N2 f P H))).
@@ -2941,7 +2943,7 @@ apply (le_not_lt N1 (proj1_sig k) H21 (proj2_sig k)).
 move=> N1 N2 g H18 H19.
 elim.
 move=> P H20 H21.
-suff: ((exist Bijective (fun (k : {n : nat | (n < N2)%nat}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, k = g l) with
+suff: ((exist Bijective (fun (k : {n : nat | (n < N2)}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)}, k = g l) with
   | left H0 => g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H0)))
   | right _ => k
 end) (H17 N1 N2 g P H18)) = PermutationID N2).
@@ -2954,12 +2956,12 @@ rewrite (PermutationIDParity N2).
 apply (PermutationIDParity N1).
 apply sig_map.
 apply functional_extensionality.
-apply (fun (k : {n : nat | (n < N1)%nat}) => H21 k (le_0_n (proj1_sig k))).
+apply (fun (k : {n : nat | (n < N1)}) => H21 k (le_0_n (proj1_sig k))).
 apply sig_map.
 apply functional_extensionality.
 move=> k.
 simpl.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)%nat}), k = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)}), k = g l)).
 move=> H22.
 rewrite (H21 (proj1_sig (H16 N1 N2 g k H18 H22)) (le_0_n (proj1_sig (proj1_sig (H16 N1 N2 g k H18 H22))))).
 rewrite - (proj2_sig (H16 N1 N2 g k H18 H22)).
@@ -2967,7 +2969,7 @@ reflexivity.
 move=> H22.
 reflexivity.
 move=> n H20 P H21 H22.
-elim (classic (proj1_sig P (exist (fun (k : nat) => (k < N1)%nat) n H21) = (exist (fun (k : nat) => (k < N1)%nat) n H21))).
+elim (classic (proj1_sig P (exist (fun (k : nat) => (k < N1)) n H21) = (exist (fun (k : nat) => (k < N1)) n H21))).
 move=> H23.
 apply (H20 P (le_trans n (S n) N1 (le_S n n (le_n n)) H21)).
 move=> k H24.
@@ -2975,7 +2977,7 @@ elim (le_lt_or_eq n (proj1_sig k) H24).
 move=> H25.
 apply (H22 k H25).
 move=> H25.
-suff: (k = (exist (fun k : nat => (k < N1)%nat) n H21)).
+suff: (k = (exist (fun k : nat => (k < N1)) n H21)).
 move=> H26.
 rewrite H26.
 apply H23.
@@ -2983,17 +2985,17 @@ apply sig_map.
 rewrite - H25.
 reflexivity.
 move=> H23.
-suff: (proj1_sig (proj1_sig P (exist (fun k : nat => (k < N1)%nat) n H21)) < n)%nat.
+suff: (proj1_sig (proj1_sig P (exist (fun k : nat => (k < N1)) n H21)) < n).
 move=> H24.
-suff: (PermutationParity N1 (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun (k : nat) => k < N1) n H21)) (exist (fun k : nat => k < N1) n H21)) P) = PermutationParity N2 (PermutationCompose N2 (PermutationSwap N2 (g (proj1_sig P (exist (fun (k : nat) => k < N1) n H21))) (g (exist (fun k : nat => k < N1) n H21))) (exist Bijective (fun k : {n0 : nat | (n0 < N2)%nat} => match excluded_middle_informative (exists l : {n0 : nat | (n0 < N1)%nat}, k = g l) with
+suff: (PermutationParity N1 (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun (k : nat) => k < N1) n H21)) (exist (fun k : nat => k < N1) n H21)) P) = PermutationParity N2 (PermutationCompose N2 (PermutationSwap N2 (g (proj1_sig P (exist (fun (k : nat) => k < N1) n H21))) (g (exist (fun k : nat => k < N1) n H21))) (exist Bijective (fun k : {n0 : nat | (n0 < N2)} => match excluded_middle_informative (exists l : {n0 : nat | (n0 < N1)}, k = g l) with
   | left H0 => g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H0)))
   | right _ => k
-end) (H17 N1 N2 g P H18))))%nat.
+end) (H17 N1 N2 g P H18)))).
 rewrite (PermutationComposeParity N1).
 rewrite (PermutationComposeParity N2).
 rewrite (PermutationSwapParity N1).
 rewrite (PermutationSwapParity N2).
-elim (PermutationParity N2 (exist Bijective (fun k : {n0 : nat | (n0 < N2)%nat} => match excluded_middle_informative (exists l : {n0 : nat | (n0 < N1)%nat}, k = g l) with
+elim (PermutationParity N2 (exist Bijective (fun k : {n0 : nat | (n0 < N2)} => match excluded_middle_informative (exists l : {n0 : nat | (n0 < N1)}, k = g l) with
   | left H0 => g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H0)))
   | right _ => k
 end) (H17 N1 N2 g P H18))).
@@ -3016,30 +3018,30 @@ apply H23.
 apply H18.
 apply H25.
 apply H23.
-suff: ((PermutationCompose N2 (PermutationSwap N2 (g (proj1_sig P (exist (fun k : nat => (k < N1)%nat) n H21))) (g (exist (fun k : nat => (k < N1)%nat) n H21))) (exist Bijective (fun k : {n0 : nat | (n0 < N2)%nat} => match excluded_middle_informative (exists l : {n0 : nat | (n0 < N1)%nat}, k = g l) with
+suff: ((PermutationCompose N2 (PermutationSwap N2 (g (proj1_sig P (exist (fun k : nat => (k < N1)) n H21))) (g (exist (fun k : nat => (k < N1)) n H21))) (exist Bijective (fun k : {n0 : nat | (n0 < N2)} => match excluded_middle_informative (exists l : {n0 : nat | (n0 < N1)}, k = g l) with
   | left H0 => g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H0)))
   | right _ => k
-end) (H17 N1 N2 g P H18))) = (exist Bijective (fun k : {n : nat | (n < N2)%nat} => match excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, k = g l) with
-  | left H0 => g (proj1_sig (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21)) (exist (fun k0 : nat => (k0 < N1)%nat) n H21)) P) (proj1_sig (H16 N1 N2 g k H18 H0)))
+end) (H17 N1 N2 g P H18))) = (exist Bijective (fun k : {n : nat | (n < N2)} => match excluded_middle_informative (exists l : {n : nat | (n < N1)}, k = g l) with
+  | left H0 => g (proj1_sig (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21)) (exist (fun k0 : nat => (k0 < N1)) n H21)) P) (proj1_sig (H16 N1 N2 g k H18 H0)))
   | right _ => k
-end) (H17 N1 N2 g (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun k : nat => (k < N1)%nat) n H21)) (exist (fun k : nat => (k < N1)%nat) n H21)) P) H18))).
+end) (H17 N1 N2 g (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun k : nat => (k < N1)) n H21)) (exist (fun k : nat => (k < N1)) n H21)) P) H18))).
 move=> H25.
 rewrite H25.
-apply (H20 (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun k : nat => (k < N1)%nat) n H21)) (exist (fun k : nat => (k < N1)%nat) n H21)) P)).
+apply (H20 (PermutationCompose N1 (PermutationSwap N1 (proj1_sig P (exist (fun k : nat => (k < N1)) n H21)) (exist (fun k : nat => (k < N1)) n H21)) P)).
 apply (le_trans n (S n) N1 (le_S n n (le_n n)) H21).
 move=> k H26.
 unfold PermutationCompose.
 unfold PermutationSwap.
 unfold Basics.compose.
 simpl.
-elim (excluded_middle_informative (proj1_sig P k = proj1_sig P (exist (fun (l : nat) => (l < N1)%nat) n H21))).
+elim (excluded_middle_informative (proj1_sig P k = proj1_sig P (exist (fun (l : nat) => (l < N1)) n H21))).
 move=> H27.
-apply (BijInj {l : nat | (l < N1)%nat} {l : nat | (l < N1)%nat} (proj1_sig P) (proj2_sig P)).
+apply (BijInj {l : nat | (l < N1)} {l : nat | (l < N1)} (proj1_sig P) (proj2_sig P)).
 rewrite H27.
 reflexivity.
 elim (le_lt_or_eq n (proj1_sig k)).
 move=> H27 H28.
-elim (excluded_middle_informative (proj1_sig P k = exist (fun k0 : nat => (k0 < N1)%nat) n H21)).
+elim (excluded_middle_informative (proj1_sig P k = exist (fun k0 : nat => (k0 < N1)) n H21)).
 move=> H29.
 apply False_ind.
 apply (lt_irrefl (proj1_sig (proj1_sig P k))).
@@ -3051,7 +3053,7 @@ apply (H22 k H27).
 move=> H27 H28.
 apply False_ind.
 apply H28.
-suff: ((exist (fun (l : nat) => (l < N1)%nat) n H21) = k).
+suff: ((exist (fun (l : nat) => (l < N1)) n H21) = k).
 move=> H29.
 rewrite H29.
 reflexivity.
@@ -3065,11 +3067,11 @@ unfold Basics.compose.
 simpl.
 apply functional_extensionality.
 move=> k.
-elim (excluded_middle_informative (exists (l : {n0 : nat | (n0 < N1)%nat}), k = g l)).
+elim (excluded_middle_informative (exists (l : {n0 : nat | (n0 < N1)}), k = g l)).
 move=> H25.
-elim (excluded_middle_informative (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25)) = proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21))).
+elim (excluded_middle_informative (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25)) = proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21))).
 move=> H26.
-elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21)))).
+elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21)))).
 move=> H27.
 reflexivity.
 move=> H27.
@@ -3078,15 +3080,15 @@ apply H27.
 rewrite H26.
 reflexivity.
 move=> H26.
-elim (excluded_middle_informative (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25)) = exist (fun k0 : nat => (k0 < N1)%nat) n H21)).
+elim (excluded_middle_informative (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25)) = exist (fun k0 : nat => (k0 < N1)) n H21)).
 move=> H27.
-elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21)))).
+elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21)))).
 move=> H28.
 rewrite - H28.
 rewrite H27.
 reflexivity.
 move=> H28.
-elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (exist (fun k0 : nat => (k0 < N1)%nat) n H21))).
+elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (exist (fun k0 : nat => (k0 < N1)) n H21))).
 move=> H29.
 reflexivity.
 move=> H29.
@@ -3095,14 +3097,14 @@ apply H29.
 rewrite H27.
 reflexivity.
 move=> H27.
-elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21)))).
+elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21)))).
 move=> H28.
 apply False_ind.
 apply H26.
 apply H18.
 apply H28.
 move=> H28.
-elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (exist (fun k0 : nat => (k0 < N1)%nat) n H21))).
+elim (excluded_middle_informative (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H18 H25))) = g (exist (fun k0 : nat => (k0 < N1)) n H21))).
 move=> H29.
 apply False_ind.
 apply H27.
@@ -3111,28 +3113,28 @@ apply H29.
 move=> H29.
 reflexivity.
 move=> H25.
-elim (excluded_middle_informative (k = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21)))).
+elim (excluded_middle_informative (k = g (proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21)))).
 move=> H26.
 apply False_ind.
 apply H25.
-exists (proj1_sig P (exist (fun k0 : nat => (k0 < N1)%nat) n H21)).
+exists (proj1_sig P (exist (fun k0 : nat => (k0 < N1)) n H21)).
 apply H26.
 move=> H26.
-elim (excluded_middle_informative (k = g (exist (fun k0 : nat => (k0 < N1)%nat) n H21))).
+elim (excluded_middle_informative (k = g (exist (fun k0 : nat => (k0 < N1)) n H21))).
 move=> H27.
 apply False_ind.
 apply H25.
-exists (exist (fun k0 : nat => (k0 < N1)%nat) n H21).
+exists (exist (fun k0 : nat => (k0 < N1)) n H21).
 apply H27.
 move=> H27.
 reflexivity.
-elim (nat_total_order (proj1_sig (proj1_sig P (exist (fun k : nat => (k < N1)%nat) n H21))) n).
+elim (nat_total_order (proj1_sig (proj1_sig P (exist (fun k : nat => (k < N1)) n H21))) n).
 apply.
 move=> H24.
 apply False_ind.
 apply H23.
-apply (BijInj {n : nat | (n < N1)%nat} {n : nat | (n < N1)%nat} (proj1_sig P) (proj2_sig P)).
-apply (H22 (proj1_sig P (exist (fun k : nat => (k < N1)%nat) n H21)) H24).
+apply (BijInj {n : nat | (n < N1)} {n : nat | (n < N1)} (proj1_sig P) (proj2_sig P)).
+apply (H22 (proj1_sig P (exist (fun k : nat => (k < N1)) n H21)) H24).
 move=> H24.
 apply H23.
 apply sig_map.
@@ -3140,15 +3142,15 @@ apply H24.
 move=> N1 N2 g P H17.
 elim (proj2_sig P).
 move=> q H18.
-exists (fun (k : {n : nat | (n < N2)%nat}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, k = g l) with
+exists (fun (k : {n : nat | (n < N2)}) => match excluded_middle_informative (exists l : {n : nat | (n < N1)}, k = g l) with
   | left H0 => g (q (proj1_sig (H16 N1 N2 g k H17 H0)))
   | right _ => k
 end).
 apply conj.
 move=> k.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)%nat}), k = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)}), k = g l)).
 move=> H19.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N1)%nat}, g (proj1_sig P (proj1_sig (H16 N1 N2 g k H17 H19))) = g l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N1)}, g (proj1_sig P (proj1_sig (H16 N1 N2 g k H17 H19))) = g l)).
 move=> H20.
 suff: ((proj1_sig (H16 N1 N2 g (g (proj1_sig P (proj1_sig (H16 N1 N2 g k H17 H19)))) H17 H20)) = (proj1_sig P (proj1_sig (H16 N1 N2 g k H17 H19)))).
 move=> H21.
@@ -3165,16 +3167,16 @@ apply H20.
 exists (proj1_sig P (proj1_sig (H16 N1 N2 g k H17 H19))).
 reflexivity.
 move=> H19.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)%nat}), k = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)}), k = g l)).
 move=> H20.
 apply False_ind.
 apply (H19 H20).
 move=> H20.
 reflexivity.
 move=> k.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)%nat}), k = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)}), k = g l)).
 move=> H19.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)%nat}), g (q (proj1_sig (H16 N1 N2 g k H17 H19))) = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)}), g (q (proj1_sig (H16 N1 N2 g k H17 H19))) = g l)).
 move=> H20.
 suff: ((proj1_sig (H16 N1 N2 g (g (q (proj1_sig (H16 N1 N2 g k H17 H19)))) H17 H20)) = (q (proj1_sig (H16 N1 N2 g k H17 H19)))).
 move=> H21.
@@ -3191,7 +3193,7 @@ apply H20.
 exists (q (proj1_sig (H16 N1 N2 g k H17 H19))).
 reflexivity.
 move=> H19.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)%nat}), k = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N1)}), k = g l)).
 move=> H20.
 apply False_ind.
 apply (H19 H20).
@@ -3199,7 +3201,7 @@ move=> H20.
 reflexivity.
 move=> N1 N2 p k H16 H17.
 apply constructive_definite_description.
-apply (unique_existence (fun (m : {n : nat | (n < N1)%nat}) => k = p m)).
+apply (unique_existence (fun (m : {n : nat | (n < N1)}) => k = p m)).
 apply conj.
 apply H17.
 move=> k1 k2 H18 H19.
@@ -3211,21 +3213,21 @@ apply H14.
 rewrite (MySumF2Pair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (FPCM f) (fun (u v : Permutation N) => Fmul f (Fmul f match PermutationParity N u with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig u k))))) (Fmul f match PermutationParity N v with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig u k))))) (Fmul f match PermutationParity N v with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => B (c k) (proj1_sig v k)))))).
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => B (c k) (proj1_sig v k)))))).
 unfold Determinant at 1.
 apply (FiniteSetInduction (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (fun (E : {X : Ensemble (Permutation N) | Finite (Permutation N) X}) => Fmul f (MySumF2 (Permutation N) E (FPCM f) (fun P : Permutation N => Fmul f match PermutationParity N P with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig P k)))))) (Determinant f N (fun x y : {n : nat | (n < N)%nat} => B (c x) y)) = MySumF2 (Permutation N) E (FPCM f) (fun u : Permutation N => MySumF2 (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (FPCM f) (fun v : Permutation N => Fmul f (Fmul f match PermutationParity N u with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig P k)))))) (Determinant f N (fun x y : {n : nat | (n < N)} => B (c x) y)) = MySumF2 (Permutation N) E (FPCM f) (fun u : Permutation N => MySumF2 (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (FPCM f) (fun v : Permutation N => Fmul f (Fmul f match PermutationParity N u with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => A k (c (proj1_sig u k))))) (Fmul f match PermutationParity N v with
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => A k (c (proj1_sig u k))))) (Fmul f match PermutationParity N v with
   | ON => Fopp f (FI f)
   | OFF => FI f
-end (MySumF2 {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)%nat} => B (c k) (proj1_sig v k)))))))).
+end (MySumF2 {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f) (fun k : {n : nat | (n < N)} => B (c k) (proj1_sig v k)))))))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -3256,26 +3258,26 @@ apply H13.
 apply H13.
 apply H9.
 apply H9.
-suff: (forall (u : (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N))), In (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N)) (proj1_sig (FinitePair ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) u -> Injective (fst u)).
+suff: (forall (u : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N))), In (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) (proj1_sig (FinitePair ({n : nat | (n < N)} -> {n : nat | (n < M)}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) u -> Injective (fst u)).
 move=> H7 u1 u2 H8 H9 H10.
 suff: (proj1_sig (exist Bijective match excluded_middle_informative (Injective (fst u1)) with
-  | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u1 l) with
-      | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c))))
+  | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
+      | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
     end
   end
-  | right _ => fun k : {n : nat | (n < M + N)%nat} => k
+  | right _ => fun k : {n : nat | (n < M + N)} => k
 end (H6 u1)) = proj1_sig (exist Bijective match excluded_middle_informative (Injective (fst u2)) with
-  | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u2 l) with
-      | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => s < M) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c))))
+  | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u2 l) with
+      | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
     end
   end
-  | right _ => fun k : {n : nat | (n < M + N)%nat} => k
+  | right _ => fun k : {n : nat | (n < M + N)} => k
 end (H6 u2))).
 simpl.
 elim (excluded_middle_informative (Injective (fst u1))).
@@ -3293,13 +3295,13 @@ move=> k.
 apply H11.
 rewrite {2} H14.
 apply sig_map.
-suff: (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) k)) = let temp := (fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u1 l) with
-    | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c))))%nat (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H11 c))))
+suff: (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) k)) = let temp := (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
+    | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
   end
-end) in proj1_sig (temp (exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)))).
+end) in proj1_sig (temp (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig k) (H5 k)))).
 move=> H15.
 rewrite H15.
 rewrite H13.
@@ -3307,35 +3309,35 @@ simpl.
 elim (le_lt_dec M (M + proj1_sig k)).
 move=> H16.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) H16)) = k).
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16)) = k).
 move=> H17.
 rewrite H17.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) H16))) (proj1_sig k) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) H16)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16))) (proj1_sig k) M).
+apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16)).
 move=> H16.
 apply False_ind.
 apply (lt_irrefl M).
-apply (le_trans (S M) (S (M + proj1_sig k)%nat) M).
+apply (le_trans (S M) (S (M + proj1_sig k)) M).
 apply le_n_S.
 apply le_plus_l.
 apply H16.
 simpl.
-elim (le_lt_dec M (M + proj1_sig k)%nat).
+elim (le_lt_dec M (M + proj1_sig k)).
 move=> H15.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) H15)) = k).
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15)) = k).
 move=> H16.
 rewrite H16.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) H15))) (proj1_sig k) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig k)%nat (H5 k)) H15)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15))) (proj1_sig k) M).
+apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15)).
 move=> H15.
 apply False_ind.
 apply (lt_irrefl M).
-apply (le_trans (S M) (S (M + proj1_sig k)%nat) M).
+apply (le_trans (S M) (S (M + proj1_sig k)) M).
 apply le_n_S.
 apply le_plus_l.
 apply H15.
@@ -3344,13 +3346,13 @@ apply functional_extensionality.
 move=> k.
 apply sig_map.
 apply (plus_reg_l (proj1_sig (proj1_sig (snd (snd u1)) k)) (proj1_sig (proj1_sig (snd (snd u2)) k)) M).
-suff: ((M + proj1_sig (proj1_sig (snd (snd u1)) k))%nat = let temp := (fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u1 l) with
-    | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c))))%nat (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H11 c))))
+suff: ((M + proj1_sig (proj1_sig (snd (snd u1)) k)) = let temp := (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
+    | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
   end
-end) in proj1_sig (temp (exist (fun (s : nat) => (s < M + N)%nat) (proj1_sig (fst u1 k)) (H4 (fst u1 k))))).
+end) in proj1_sig (temp (exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst u1 k)) (H4 (fst u1 k))))).
 move=> H15.
 rewrite H15.
 rewrite H13.
@@ -3361,14 +3363,14 @@ move=> H16.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (fst u2 k)) H16 (proj2_sig (fst u2 k))).
 move=> H16.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun (s : nat) => (s < M)%nat) (proj1_sig (fst u2 k)) H16 = fst u2 l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun (s : nat) => (s < M)) (proj1_sig (fst u2 k)) H16 = fst u2 l)).
 move=> H17.
-suff: (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)%nat) (proj1_sig (fst u2 k)) H16) H12 H17) = k).
+suff: (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)) (proj1_sig (fst u2 k)) H16) H12 H17) = k).
 move=> H18.
 rewrite H18.
 reflexivity.
 apply H12.
-rewrite - (proj2_sig (H3 (fst u2) (exist (fun s : nat => (s < M)%nat) (proj1_sig (fst u2 k)) H16) H12 H17)).
+rewrite - (proj2_sig (H3 (fst u2) (exist (fun s : nat => (s < M)) (proj1_sig (fst u2 k)) H16) H12 H17)).
 apply sig_map.
 reflexivity.
 move=> H17.
@@ -3383,14 +3385,14 @@ move=> H15.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (fst u1 k)) H15 (proj2_sig (fst u1 k))).
 move=> H15.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun (s : nat) => (s < M)%nat) (proj1_sig (fst u1 k)) H15 = fst u1 l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun (s : nat) => (s < M)) (proj1_sig (fst u1 k)) H15 = fst u1 l)).
 move=> H16.
-suff: ((proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig (fst u1 k)) H15) H11 H16)) = k).
+suff: ((proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig (fst u1 k)) H15) H11 H16)) = k).
 move=> H17.
 rewrite H17.
 reflexivity.
 apply H11.
-rewrite - (proj2_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig (fst u1 k)) H15) H11 H16)).
+rewrite - (proj2_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig (fst u1 k)) H15) H11 H16)).
 apply sig_map.
 reflexivity.
 move=> H16.
@@ -3399,13 +3401,13 @@ apply H16.
 exists k.
 apply sig_map.
 reflexivity.
-suff: (forall (p q : {n : nat | (n < N)%nat}), (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (fst u1 p) < proj1_sig (fst u1 q))%nat).
+suff: (forall (p q : {n : nat | (n < N)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (fst u1 p) < proj1_sig (fst u1 q))).
 move=> H14.
-suff: (forall (p q : {n : nat | (n < N)%nat}), (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (fst u2 p) < proj1_sig (fst u2 q))%nat).
+suff: (forall (p q : {n : nat | (n < N)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (fst u2 p) < proj1_sig (fst u2 q))).
 move=> H15.
-suff: (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (k : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 k)) = Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (k : {n : nat | (n < N)%nat}) => proj1_sig (fst u2 k))).
+suff: (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u1 k)) = Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u2 k))).
 move=> H16.
-suff: (forall (m : nat), (m <= N)%nat -> (forall (k : {n : nat | (n < N)%nat}), (proj1_sig k < m)%nat -> proj1_sig (fst u1 k) = proj1_sig (fst u2 k))).
+suff: (forall (m : nat), (m <= N) -> (forall (k : {n : nat | (n < N)}), (proj1_sig k < m) -> proj1_sig (fst u1 k) = proj1_sig (fst u2 k))).
 move=> H17.
 apply functional_extensionality.
 move=> k.
@@ -3420,20 +3422,20 @@ elim (le_lt_or_eq (proj1_sig k) m).
 move=> H20.
 apply (H17 (le_trans m (S m) N (le_S m m (le_n m)) H18) k H20).
 move=> H20.
-suff: (Inhabited nat (Intersection nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)%nat}), (proj1_sig k < m)%nat -> (proj1_sig (fst u1 k) < l)%nat) )).
+suff: (Inhabited nat (Intersection nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)}), (proj1_sig k < m) -> (proj1_sig (fst u1 k) < l)) )).
 move=> H21.
-suff: (proj1_sig (fst u1 k) = proj1_sig (min_nat_get (Intersection nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)%nat}), (proj1_sig k < m)%nat -> (proj1_sig (fst u1 k) < l)%nat) ) H21)).
+suff: (proj1_sig (fst u1 k) = proj1_sig (min_nat_get (Intersection nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)}), (proj1_sig k < m) -> (proj1_sig (fst u1 k) < l)) ) H21)).
 move=> H22.
 rewrite H22.
-suff: (Inhabited nat (Intersection nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u2 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)%nat}), (proj1_sig k < m)%nat -> (proj1_sig (fst u2 k) < l)%nat) )).
+suff: (Inhabited nat (Intersection nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u2 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)}), (proj1_sig k < m) -> (proj1_sig (fst u2 k) < l)) )).
 move=> H23.
-suff: (proj1_sig (fst u2 k) = proj1_sig (min_nat_get (Intersection nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u2 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)%nat}), (proj1_sig k < m)%nat -> (proj1_sig (fst u2 k) < l)%nat) ) H23)).
+suff: (proj1_sig (fst u2 k) = proj1_sig (min_nat_get (Intersection nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u2 l))) (fun (l : nat) => forall (k : {n : nat | (n < N)}), (proj1_sig k < m) -> (proj1_sig (fst u2 k) < l)) ) H23)).
 move=> H24.
 rewrite H24.
 suff: (forall (E1 E2 : Ensemble nat), E1 = E2 -> forall (H1 : Inhabited nat E1) (H2 : Inhabited nat E2), proj1_sig (min_nat_get E1 H1) = proj1_sig (min_nat_get E2 H2)).
 apply.
 rewrite H16.
-suff: ((fun (l : nat) => forall (s : {n : nat | (n < N)%nat}), (proj1_sig s < m)%nat -> (proj1_sig (fst u1 s) < l)%nat) = (fun (l : nat) => forall (s : {n : nat | (n < N)%nat}), (proj1_sig s < m)%nat -> (proj1_sig (fst u2 s) < l)%nat)).
+suff: ((fun (l : nat) => forall (s : {n : nat | (n < N)}), (proj1_sig s < m) -> (proj1_sig (fst u1 s) < l)) = (fun (l : nat) => forall (s : {n : nat | (n < N)}), (proj1_sig s < m) -> (proj1_sig (fst u2 s) < l))).
 move=> H25.
 rewrite H25.
 reflexivity.
@@ -3454,7 +3456,7 @@ rewrite H28.
 reflexivity.
 apply proof_irrelevance.
 apply le_antisym.
-elim (proj1 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun (l : {n : nat | n < N}) => proj1_sig (fst u2 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u2 s) < l)) H23)))%nat.
+elim (proj1 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun (l : {n : nat | n < N}) => proj1_sig (fst u2 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u2 s) < l)) H23))).
 move=> m1.
 elim.
 move=> l1 H24 m2 H25 H26.
@@ -3480,24 +3482,24 @@ rewrite {1} H25.
 apply (H26 l1).
 rewrite - H20.
 apply H27.
-apply (proj2 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun l : {n : nat | n < N} => proj1_sig (fst u2 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u2 s) < l)) H23)) (proj1_sig (fst u2 k)))%nat.
+apply (proj2 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun l : {n : nat | n < N} => proj1_sig (fst u2 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u2 s) < l)) H23)) (proj1_sig (fst u2 k))).
 apply Intersection_intro.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u2 l)) k).
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u2 l)) k).
+apply (Full_intro {n : nat | (n < N)} k).
 reflexivity.
 move=> l.
 rewrite - H20.
 apply (H15 l k).
-apply (Inhabited_intro nat (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun l : {n : nat | n < N} => proj1_sig (fst u2 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u2 s) < l)) (proj1_sig (fst u2 k)))%nat.
+apply (Inhabited_intro nat (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun l : {n : nat | n < N} => proj1_sig (fst u2 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u2 s) < l)) (proj1_sig (fst u2 k))).
 apply Intersection_intro.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u2 l)) k).
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u2 l)) k).
+apply (Full_intro {n : nat | (n < N)} k).
 reflexivity.
 move=> l.
 rewrite - H20.
 apply (H15 l k).
 apply le_antisym.
-elim (proj1 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (s : {n : nat | (n < N)%nat}), (proj1_sig s < m)%nat -> (proj1_sig (fst u1 s) < l)%nat)) H21)))%nat.
+elim (proj1 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (s : {n : nat | (n < N)}), (proj1_sig s < m) -> (proj1_sig (fst u1 s) < l))) H21))).
 move=> m1.
 elim.
 move=> l1 H22 m2 H23 H24.
@@ -3523,28 +3525,28 @@ rewrite {1} H23.
 apply (H24 l1).
 rewrite - H20.
 apply H25.
-apply (proj2 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun l : {n : nat | n < N} => proj1_sig (fst u1 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u1 s) < l)) H21)) (proj1_sig (fst u1 k)))%nat.
+apply (proj2 (proj2_sig (min_nat_get (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun l : {n : nat | n < N} => proj1_sig (fst u1 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u1 s) < l)) H21)) (proj1_sig (fst u1 k))).
 apply Intersection_intro.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 l)) k).
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u1 l)) k).
+apply (Full_intro {n : nat | (n < N)} k).
 reflexivity.
 move=> l.
 rewrite - H20.
 apply (H14 l k).
-apply (Inhabited_intro nat (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun (l : {n : nat | n < N}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u1 s) < l)) (proj1_sig (fst u1 k)))%nat.
+apply (Inhabited_intro nat (Intersection nat (Im {n : nat | n < N} nat (Full_set {n : nat | n < N}) (fun (l : {n : nat | n < N}) => proj1_sig (fst u1 l))) (fun (l : nat) => forall (s : {n : nat | n < N}), proj1_sig s < m -> proj1_sig (fst u1 s) < l)) (proj1_sig (fst u1 k))).
 apply Intersection_intro.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (l : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 l)) k).
-apply (Full_intro {n : nat | (n < N)%nat} k).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (l : {n : nat | (n < N)}) => proj1_sig (fst u1 l)) k).
+apply (Full_intro {n : nat | (n < N)} k).
 reflexivity.
 move=> l.
 rewrite - H20.
 apply (H14 l k).
 apply le_S_n.
 apply H19.
-suff: (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun k : {n : nat | (n < N)%nat} => proj1_sig (fst u1 k)) = Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig k)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u1 l) with
-    | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c))))%nat (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H11 c))))
+suff: (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun k : {n : nat | (n < N)} => proj1_sig (fst u1 k)) = Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
+    | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
   end
 end))).
@@ -3559,8 +3561,8 @@ move=> x H17 y H18.
 rewrite H18.
 unfold Basics.compose.
 unfold In.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (k : {n : nat | (n < N)%nat}) => proj1_sig (fst u2 k)) (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N x H17)))).
-apply (Full_intro {n : nat | (n < N)%nat}).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u2 k)) (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N x H17)))).
+apply (Full_intro {n : nat | (n < N)}).
 elim (le_lt_dec M (proj1_sig x)).
 move=> H19.
 suff: (H19 = H17).
@@ -3577,32 +3579,32 @@ move=> x H17 y H18.
 rewrite H18.
 elim (proj2_sig (fst (snd u2))).
 move=> invg H19.
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig k)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b)))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u2 l) with
-    | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => s < M) (proj1_sig k) b) H12 c))))%nat (H5 (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H12 c))))
+apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b)))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u2 l) with
+    | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => s < M) (proj1_sig k) b) H12 c)))) (H5 (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H12 c))))
     | right _ => k
   end
-end)) (exist (fun (s : nat) => (s < M + N)%nat) (M + (proj1_sig (invg x)))%nat (H5 (invg x)))).
+end)) (exist (fun (s : nat) => (s < M + N)) (M + (proj1_sig (invg x))) (H5 (invg x)))).
 apply le_plus_l.
 unfold Basics.compose.
 simpl.
-elim (le_lt_dec M (M + (proj1_sig (invg x)))%nat).
+elim (le_lt_dec M (M + (proj1_sig (invg x)))).
 move=> H20.
-suff: ((proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H20))) = x).
+suff: ((proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20))) = x).
 move=> H21.
 rewrite H21.
 reflexivity.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H20)) = invg x).
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20)) = invg x).
 move=> H21.
 rewrite H21.
 apply (proj2 H19 x).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H20))) (proj1_sig (invg x)) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H20)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20))) (proj1_sig (invg x)) M).
+apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20)).
 move=> H20.
 apply False_ind.
-apply (lt_not_le (M + proj1_sig (invg x))%nat M H20).
+apply (lt_not_le (M + proj1_sig (invg x)) M H20).
 apply le_plus_l.
 apply Extensionality_Ensembles.
 apply conj.
@@ -3612,32 +3614,32 @@ move=> x H16 y H17.
 rewrite H17.
 elim (proj2_sig (fst (snd u1))).
 move=> invg H18.
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig k)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst u1 l) with
-    | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c))))%nat (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H11 c))))
+apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
+    | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
   end
-end)) (exist (fun (s : nat) => (s < M + N)%nat) (M + (proj1_sig (invg x)))%nat (H5 (invg x)))).
+end)) (exist (fun (s : nat) => (s < M + N)) (M + (proj1_sig (invg x))) (H5 (invg x)))).
 apply le_plus_l.
 unfold Basics.compose.
 simpl.
-elim (le_lt_dec M (M + (proj1_sig (invg x)))%nat).
+elim (le_lt_dec M (M + (proj1_sig (invg x)))).
 move=> H19.
-suff: ((proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H19))) = x).
+suff: ((proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19))) = x).
 move=> H20.
 rewrite H20.
 reflexivity.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H19)) = invg x).
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19)) = invg x).
 move=> H20.
 rewrite H20.
 apply (proj2 H18 x).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H19))) (proj1_sig (invg x)) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (invg x))%nat (H5 (invg x))) H19)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19))) (proj1_sig (invg x)) M).
+apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19)).
 move=> H19.
 apply False_ind.
-apply (lt_not_le (M + proj1_sig (invg x))%nat M H19).
+apply (lt_not_le (M + proj1_sig (invg x)) M H19).
 apply le_plus_l.
 move=> m.
 elim.
@@ -3645,8 +3647,8 @@ move=> x H16 y H17.
 rewrite H17.
 unfold Basics.compose.
 unfold In.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (fun (k : {n : nat | (n < N)%nat}) => proj1_sig (fst u1 k)) (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N x H16)))).
-apply (Full_intro {n : nat | (n < N)%nat}).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u1 k)) (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N x H16)))).
+apply (Full_intro {n : nat | (n < N)}).
 elim (le_lt_dec M (proj1_sig x)).
 move=> H18.
 suff: (H18 = H16).
@@ -3694,18 +3696,18 @@ apply (H8 k2 k1 H11).
 move=> u.
 elim.
 move=> u0 H7 H8.
-suff: (exists (k : {n : nat | (n < M + N)%nat}), MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig u0 k) = FO f).
+suff: (exists (k : {n : nat | (n < M + N)}), MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig u0 k) = FO f).
 elim.
 move=> k H9.
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteSingleton {n : nat | (n < M + N)%nat} k) (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N)))).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteSingleton {n : nat | (n < M + N)} k) (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N)))).
 rewrite MySumF2Singleton.
 simpl.
 rewrite H9.
 rewrite (Fmul_O_l f).
 apply (Fmul_O_r f).
 move=> l H10.
-apply (Full_intro {n : nat | (n < M + N)%nat} l).
-suff: (~ forall (k : {n : nat | (n < M + N)%nat}), MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig u0 k) <> FO f).
+apply (Full_intro {n : nat | (n < M + N)} l).
+suff: (~ forall (k : {n : nat | (n < M + N)}), MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig u0 k) <> FO f).
 move=> H9.
 apply NNPP.
 move=> H10.
@@ -3716,35 +3718,35 @@ exists k.
 apply H11.
 move=> H9.
 apply H7.
-suff: (forall (m : {n : nat | (n < M + N)%nat}), (proj1_sig m >= M)%nat -> (proj1_sig (proj1_sig u0 m) < M)%nat).
+suff: (forall (m : {n : nat | (n < M + N)}), (proj1_sig m >= M) -> (proj1_sig (proj1_sig u0 m) < M)).
 move=> H10.
-suff: (exists (g : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}), Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (Basics.compose (fun (k : {n : nat | (n < M)%nat}) => proj1_sig k) g) = Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0)) /\ forall (p q : {n : nat | (n < N)%nat}), (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (g p) < proj1_sig (g q))%nat).
+suff: (exists (g : {n : nat | (n < N)} -> {n : nat | (n < M)}), Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (Basics.compose (fun (k : {n : nat | (n < M)}) => proj1_sig k) g) = Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0)) /\ forall (p q : {n : nat | (n < N)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (g p) < proj1_sig (g q))).
 elim.
 move=> g H11.
-suff: (exists (p1 : Permutation N), forall (m : {n : nat | (n < N)%nat}), proj1_sig (g (proj1_sig p1 m)) = proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)))).
+suff: (exists (p1 : Permutation N), forall (m : {n : nat | (n < N)}), proj1_sig (g (proj1_sig p1 m)) = proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)))).
 elim.
 move=> p1 H12.
-suff: (forall (m : {n : nat | (n < N)%nat}), (M <= proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))))%nat).
+suff: (forall (m : {n : nat | (n < N)}), (M <= proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))))).
 move=> H13.
-suff: (exists (p2 : Permutation N), forall (m : {n : nat | (n < N)%nat}), (M + proj1_sig (proj1_sig p2 m))%nat = proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m))))).
+suff: (exists (p2 : Permutation N), forall (m : {n : nat | (n < N)}), (M + proj1_sig (proj1_sig p2 m)) = proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g m)) (H4 (g m))))).
 elim.
 move=> p2 H14.
-apply (Im_intro (({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N)) (Permutation (M + N)) (proj1_sig (FinitePair ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) (fun (x : ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) * (Permutation N * Permutation N)) => exist Bijective match excluded_middle_informative (Injective (fst x)) with
-  | left a => fun k : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
-    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst x l) with
-      | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) a c))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) a c))))
+apply (Im_intro (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) (Permutation (M + N)) (proj1_sig (FinitePair ({n : nat | (n < N)} -> {n : nat | (n < M)}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) (fun (x : ({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) => exist Bijective match excluded_middle_informative (Injective (fst x)) with
+  | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst x l) with
+      | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
     end
   end
-  | right _ => fun k : {n0 : nat | (n0 < M + N)%nat} => k
+  | right _ => fun k : {n0 : nat | (n0 < M + N)} => k
 end (H6 x)) (g, (p1, p2))).
 apply conj.
 apply Intersection_intro.
 simpl.
 move=> p q H15.
 apply (proj2 H11 p q H15).
-apply (Full_intro ({n : nat | (n < N)%nat} -> {n : nat | (n < M)%nat}) g).
+apply (Full_intro ({n : nat | (n < N)} -> {n : nat | (n < M)}) g).
 apply conj.
 apply (Full_intro (Permutation N) p1).
 apply (Full_intro (Permutation N) p2).
@@ -3759,27 +3761,27 @@ move=> H16.
 apply sig_map.
 simpl.
 rewrite (H12 (proj1_sig (blockdividesub M N k H16))).
-suff: ((exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig (blockdividesub M N k H16)))%nat (H5 (proj1_sig (blockdividesub M N k H16)))) = k).
+suff: ((exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (blockdividesub M N k H16))) (H5 (proj1_sig (blockdividesub M N k H16)))) = k).
 move=> H17.
 rewrite H17.
 reflexivity.
 apply sig_map.
 apply (proj2_sig (blockdividesub M N k H16)).
 move=> H16.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig k) H16 = g l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig k) H16 = g l)).
 move=> H17.
 apply sig_map.
 simpl.
-rewrite (H14 (proj1_sig (H3 g (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H16) H15 H17))).
-rewrite - (proj2_sig (H3 g (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H16) H15 H17)).
-suff: ((exist (fun n : nat => (n < M + N)%nat) (proj1_sig (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H16)) (H4 (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H16))) = k).
+rewrite (H14 (proj1_sig (H3 g (exist (fun s : nat => (s < M)) (proj1_sig k) H16) H15 H17))).
+rewrite - (proj2_sig (H3 g (exist (fun s : nat => (s < M)) (proj1_sig k) H16) H15 H17)).
+suff: ((exist (fun n : nat => (n < M + N)) (proj1_sig (exist (fun s : nat => (s < M)) (proj1_sig k) H16)) (H4 (exist (fun s : nat => (s < M)) (proj1_sig k) H16))) = k).
 move=> H18.
 rewrite H18.
 reflexivity.
 apply sig_map.
 reflexivity.
 move=> H17.
-suff: (proj1_sig (proj1_sig u0 k) < M)%nat.
+suff: (proj1_sig (proj1_sig u0 k) < M).
 move=> H18.
 apply NNPP.
 move=> H19.
@@ -3797,7 +3799,7 @@ apply False_ind.
 apply (lt_not_le (proj1_sig k) M H16 H21).
 move=> H21.
 unfold MI.
-elim (Nat.eq_dec (proj1_sig (exist (fun n : nat => (n < M)%nat) (proj1_sig k) H21)) (proj1_sig (exist (fun n : nat => (n < M)%nat) (proj1_sig (proj1_sig u0 k)) H20))).
+elim (Nat.eq_dec (proj1_sig (exist (fun n : nat => (n < M)) (proj1_sig k) H21)) (proj1_sig (exist (fun n : nat => (n < M)) (proj1_sig (proj1_sig u0 k)) H20))).
 simpl.
 move=> H22.
 apply False_ind.
@@ -3811,26 +3813,26 @@ elim (le_or_lt M (proj1_sig (proj1_sig u0 k))).
 move=> H18.
 apply False_ind.
 apply (lt_irrefl N).
-elim (proj2 (CountCardinalBijective {x : {n : nat | (n < M + N)%nat} | (M <= proj1_sig x)%nat} N)).
+elim (proj2 (CountCardinalBijective {x : {n : nat | (n < M + N)} | (M <= proj1_sig x)} N)).
 move=> h.
 elim.
 move=> hinv H20.
-suff: (forall (m : {n : nat | (n < M + N)%nat}), In {n : nat | (n < M + N)%nat} (Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => (exists (l : {n : nat | (n < N)%nat}), (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l))) = s)) k) m -> (M <= proj1_sig (proj1_sig u0 m))%nat).
+suff: (forall (m : {n : nat | (n < M + N)}), In {n : nat | (n < M + N)} (Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => (exists (l : {n : nat | (n < N)}), (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l))) = s)) k) m -> (M <= proj1_sig (proj1_sig u0 m))).
 move=> H21.
-elim (CountCardinalInjective {x : {n : nat | (n < M + N)%nat} | In {n : nat | (n < M + N)%nat} (Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => (exists (l : {n : nat | (n < N)%nat}), (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l))) = s)) k) x} N (Basics.compose hinv (fun (y : {x : {n : nat | (n < M + N)%nat} | In {n : nat | (n < M + N)%nat} (Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => (exists (l : {n : nat | (n < N)%nat}), (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l))) = s)) k) x}) => exist (fun (x : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig x)%nat) (proj1_sig u0 (proj1_sig y)) (H21 (proj1_sig y) (proj2_sig y)) ))).
+elim (CountCardinalInjective {x : {n : nat | (n < M + N)} | In {n : nat | (n < M + N)} (Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => (exists (l : {n : nat | (n < N)}), (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l))) = s)) k) x} N (Basics.compose hinv (fun (y : {x : {n : nat | (n < M + N)} | In {n : nat | (n < M + N)} (Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => (exists (l : {n : nat | (n < N)}), (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l))) = s)) k) x}) => exist (fun (x : {n : nat | (n < M + N)}) => (M <= proj1_sig x)) (proj1_sig u0 (proj1_sig y)) (H21 (proj1_sig y) (proj2_sig y)) ))).
 move=> m H22.
 unfold lt.
 suff: (S N = m).
 move=> H23.
 rewrite H23.
 apply H22.
-rewrite (cardinal_is_functional {x : {n : nat | (n < M + N)%nat} | In {n : nat | (n < M + N)%nat} (Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => (exists (l : {n : nat | (n < N)%nat}), (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l))) = s)) k) x} (Full_set {x : {n : nat | (n < M + N)%nat} | In {n : nat | (n < M + N)%nat} (Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => (exists (l : {n : nat | (n < N)%nat}), (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l))) = s)) k) x}) m (proj2 H22) (Full_set {x : {n : nat | (n < M + N)%nat} | In {n : nat | (n < M + N)%nat} (Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => (exists (l : {n : nat | (n < N)%nat}), (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l))) = s)) k) x}) (S N))%nat.
+rewrite (cardinal_is_functional {x : {n : nat | (n < M + N)} | In {n : nat | (n < M + N)} (Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => (exists (l : {n : nat | (n < N)}), (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l))) = s)) k) x} (Full_set {x : {n : nat | (n < M + N)} | In {n : nat | (n < M + N)} (Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => (exists (l : {n : nat | (n < N)}), (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l))) = s)) k) x}) m (proj2 H22) (Full_set {x : {n : nat | (n < M + N)} | In {n : nat | (n < M + N)} (Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => (exists (l : {n : nat | (n < N)}), (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l))) = s)) k) x}) (S N)).
 reflexivity.
-apply (CardinalSigSame {n : nat | (n < M + N)%nat}).
+apply (CardinalSigSame {n : nat | (n < M + N)}).
 apply card_add.
-suff: (forall (m : nat), (m <= N)%nat -> cardinal {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), (proj1_sig l < m)%nat /\ exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l)) = s) m).
+suff: (forall (m : nat), (m <= N) -> cardinal {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), (proj1_sig l < m) /\ exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l)) = s) m).
 move=> H23.
-suff: ((fun (s : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l)) = s) = (fun (s : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), (proj1_sig l < N)%nat /\ exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l)) = s)).
+suff: ((fun (s : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l)) = s) = (fun (s : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), (proj1_sig l < N) /\ exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l)) = s)).
 move=> H24.
 rewrite H24.
 apply (H23 N).
@@ -3851,7 +3853,7 @@ exists l.
 apply (proj2 H24).
 elim.
 move=> H23.
-suff: ((fun (s : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), (proj1_sig l < 0)%nat /\ exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l)) = s) = Empty_set {n : nat | (n < M + N)%nat}).
+suff: ((fun (s : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), (proj1_sig l < 0) /\ exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l)) = s) = Empty_set {n : nat | (n < M + N)}).
 move=> H24.
 rewrite H24.
 apply card_empty.
@@ -3865,7 +3867,7 @@ apply (le_not_lt O (proj1_sig l) (le_0_n (proj1_sig l)) (proj1 H24)).
 move=> s.
 elim.
 move=> t H23 H24.
-suff: ((fun (s : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), (proj1_sig l < S t)%nat /\ exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l)) = s) = Add {n : nat | (n < M + N)%nat} (fun (s : {n : nat | (n < M + N)%nat}) => exists (l : {n : nat | (n < N)%nat}), (proj1_sig l < t)%nat /\ exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g l)) (H4 (g l)) = s) (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g (exist (fun (n : nat) => (n < N)%nat) t H24))) (H4 (g (exist (fun (n : nat) => (n < N)%nat) t H24))))).
+suff: ((fun (s : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), (proj1_sig l < S t) /\ exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l)) = s) = Add {n : nat | (n < M + N)} (fun (s : {n : nat | (n < M + N)}) => exists (l : {n : nat | (n < N)}), (proj1_sig l < t) /\ exist (fun (n : nat) => (n < M + N)) (proj1_sig (g l)) (H4 (g l)) = s) (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g (exist (fun (n : nat) => (n < N)) t H24))) (H4 (g (exist (fun (n : nat) => (n < N)) t H24))))).
 move=> H25.
 rewrite H25.
 apply card_add.
@@ -3873,13 +3875,13 @@ apply (H23 (le_trans t (S t) N (le_S t t (le_n t)) H24)).
 elim.
 move=> r H26.
 apply (lt_irrefl (proj1_sig r)).
-suff: (r = (exist (fun n : nat => (n < N)%nat) t H24)).
+suff: (r = (exist (fun n : nat => (n < N)) t H24)).
 move=> H27.
 rewrite {2} H27.
 apply (proj1 H26).
 apply H15.
 apply sig_map.
-suff: (proj1_sig (g r) = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g r)) (H4 (g r)))).
+suff: (proj1_sig (g r) = proj1_sig (exist (fun n : nat => (n < M + N)) (proj1_sig (g r)) (H4 (g r)))).
 move=> H27.
 rewrite H27.
 rewrite (proj2 H26).
@@ -3899,7 +3901,7 @@ apply H26.
 apply (proj2 H25).
 move=> H26.
 right.
-suff: ((exist (fun n : nat => (n < N)%nat) t H24) = z).
+suff: ((exist (fun n : nat => (n < N)) t H24) = z).
 move=> H27.
 rewrite H27.
 rewrite (proj2 H25).
@@ -3920,7 +3922,7 @@ apply (lt_trans (proj1_sig z) t (S t) (proj1 H25) (le_n (S t))).
 apply (proj2 H25).
 move=> z.
 elim.
-exists (exist (fun n : nat => (n < N)%nat) t H24).
+exists (exist (fun n : nat => (n < N)) t H24).
 apply conj.
 apply (le_n (S t)).
 reflexivity.
@@ -3936,8 +3938,8 @@ reflexivity.
 apply InjChain.
 move=> y1 y2 H22.
 apply sig_map.
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
-suff: (proj1_sig u0 (proj1_sig y1) = proj1_sig (exist (fun x : {n : nat | (n < M + N)%nat} => (M <= proj1_sig x)%nat) (proj1_sig u0 (proj1_sig y1)) (H21 (proj1_sig y1) (proj2_sig y1)))).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
+suff: (proj1_sig u0 (proj1_sig y1) = proj1_sig (exist (fun x : {n : nat | (n < M + N)} => (M <= proj1_sig x)) (proj1_sig u0 (proj1_sig y1)) (H21 (proj1_sig y1) (proj2_sig y1)))).
 move=> H23.
 rewrite H23.
 rewrite H22.
@@ -3958,17 +3960,17 @@ apply (H13 l).
 move=> l.
 elim.
 apply H18.
-apply (CountCardinalBijective {x : {n : nat | (n < M + N)%nat} | (M <= proj1_sig x)%nat} N).
-suff: (forall (l : {n : nat | (n < N)%nat}), (M <= M + proj1_sig l)%nat).
+apply (CountCardinalBijective {x : {n : nat | (n < M + N)} | (M <= proj1_sig x)} N).
+suff: (forall (l : {n : nat | (n < N)}), (M <= M + proj1_sig l)).
 move=> H19.
-exists (fun (l : {n : nat | (n < N)%nat}) => exist (fun (x : {n : nat | (n < M + N)%nat}) => (M <= proj1_sig x)%nat) (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig l)%nat (H5 l)) (H19 l)).
-exists (fun (l : {x : {n : nat | (n < M + N)%nat} | (M <= proj1_sig x)%nat}) => proj1_sig (blockdividesub M N (proj1_sig l) (proj2_sig l))).
+exists (fun (l : {n : nat | (n < N)}) => exist (fun (x : {n : nat | (n < M + N)}) => (M <= proj1_sig x)) (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig l) (H5 l)) (H19 l)).
+exists (fun (l : {x : {n : nat | (n < M + N)} | (M <= proj1_sig x)}) => proj1_sig (blockdividesub M N (proj1_sig l) (proj2_sig l))).
 apply conj.
 move=> t.
 apply sig_map.
 simpl.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig t)%nat (H5 t)) (H19 t)))) (proj1_sig t) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig t) (H5 t)) (H19 t)))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig t) (H5 t)) (H19 t)))) (proj1_sig t) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig t) (H5 t)) (H19 t))).
 move=> t.
 apply sig_map.
 apply sig_map.
@@ -3994,12 +3996,12 @@ apply False_ind.
 apply (lt_irrefl (proj1_sig (g k1))).
 rewrite {1} H16.
 apply (proj2 H11 k2 k1 H17).
-suff: (Bijective (fun (m : {n : nat | (n < N)%nat}) => (proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))) (H13 m))))).
+suff: (Bijective (fun (m : {n : nat | (n < N)}) => (proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))) (H13 m))))).
 move=> H14.
-exists (exist Bijective (fun (m : {n : nat | (n < N)%nat}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))) (H13 m))) H14).
+exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))) (H13 m))) H14).
 move=> m.
 simpl.
-apply (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m)))) (H13 m)))%nat.
+apply (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m)))) (H13 m))).
 apply CountInjBij.
 move=> k1 k2 H14.
 suff: ((proj1_sig (g k1)) = (proj1_sig (g k2))).
@@ -4018,25 +4020,25 @@ apply False_ind.
 apply (lt_irrefl (proj1_sig (g k1))).
 rewrite {1} H15.
 apply (proj2 H11 k2 k1 H16).
-suff: ((exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g k1)) (H4 (g k1))) = (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g k2)) (H4 (g k2)))).
+suff: ((exist (fun (n : nat) => (n < M + N)) (proj1_sig (g k1)) (H4 (g k1))) = (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g k2)) (H4 (g k2)))).
 move=> H15.
-suff: (proj1_sig (g k1) = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g k1)) (H4 (g k1)))).
+suff: (proj1_sig (g k1) = proj1_sig (exist (fun n : nat => (n < M + N)) (proj1_sig (g k1)) (H4 (g k1)))).
 move=> H16.
 rewrite H16.
 rewrite H15.
 reflexivity.
 reflexivity.
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
-rewrite - (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g k1)) (H4 (g k1)))) (H13 k1))).
+rewrite - (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g k1)) (H4 (g k1)))) (H13 k1))).
 rewrite H14.
-apply (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g k2)) (H4 (g k2)))) (H13 k2))).
+apply (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g k2)) (H4 (g k2)))) (H13 k2))).
 move=> m.
-elim (le_or_lt M (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))))).
+elim (le_or_lt M (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))))).
 apply.
 move=> H13.
 apply False_ind.
-apply (H9 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m))))%nat.
+apply (H9 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m)))).
 unfold MBlockW.
 unfold MBlockH.
 simpl.
@@ -4045,29 +4047,29 @@ move=> H14.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (g m)) H14 (proj2_sig (g m))).
 move=> H14.
-elim (le_lt_dec M (proj1_sig (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))))).
+elim (le_lt_dec M (proj1_sig (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))))).
 move=> H15.
 apply False_ind.
-apply (le_not_lt M (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m))))) H15 H13)%nat.
+apply (le_not_lt M (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m))))) H15 H13).
 move=> H15.
 unfold MI.
 simpl.
-elim (Nat.eq_dec (proj1_sig (g m)) (proj1_sig (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))))).
+elim (Nat.eq_dec (proj1_sig (g m)) (proj1_sig (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))))).
 move=> H16.
 apply False_ind.
-suff: (exists (k : {n : nat | (n < M + N)%nat}), (M <= proj1_sig k)%nat /\ proj1_sig (g m) = proj1_sig (proj1_sig u0 k)).
+suff: (exists (k : {n : nat | (n < M + N)}), (M <= proj1_sig k) /\ proj1_sig (g m) = proj1_sig (proj1_sig u0 k)).
 elim.
 move=> k H17.
 apply (le_not_lt M (proj1_sig k) (proj1 H17)).
-suff: (k = (exist (fun n : nat => (n < M + N)%nat) (proj1_sig (g m)) (H4 (g m)))).
+suff: (k = (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))).
 move=> H18.
 rewrite H18.
 apply (proj2_sig (g m)).
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
 rewrite - (proj2 H17).
 apply H16.
-suff: (In nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) g)) (proj1_sig (g m))).
+suff: (In nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) g)) (proj1_sig (g m))).
 rewrite (proj1 H11).
 elim.
 move=> l H17 x H18.
@@ -4076,47 +4078,47 @@ apply conj.
 apply H17.
 rewrite H18.
 reflexivity.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) g) m).
-apply (Full_intro {n : nat | (n < N)%nat} m).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) g) m).
+apply (Full_intro {n : nat | (n < N)} m).
 reflexivity.
 move=> H16.
 reflexivity.
-suff: (forall (m : {n : nat | (n < N)%nat}), {k : {n : nat | (n < N)%nat} | proj1_sig (g k) = proj1_sig (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)))}).
+suff: (forall (m : {n : nat | (n < N)}), {k : {n : nat | (n < N)} | proj1_sig (g k) = proj1_sig (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m) (H5 m)))}).
 move=> H12.
-suff: (Bijective (fun (m : {n : nat | (n < N)%nat}) => proj1_sig (H12 m))).
+suff: (Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (H12 m))).
 move=> H13.
-exists (exist Bijective (fun (m : {n : nat | (n < N)%nat}) => proj1_sig (H12 m)) H13).
+exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (H12 m)) H13).
 move=> m.
 apply (proj2_sig (H12 m)).
 apply CountInjBij.
 move=> k1 k2 H13.
 apply sig_map.
 apply (plus_reg_l (proj1_sig k1) (proj1_sig k2) M).
-suff: ((exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k1)%nat (H5 k1)) = (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig k2)%nat (H5 k2))).
+suff: ((exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k1) (H5 k1)) = (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig k2) (H5 k2))).
 move=> H14.
-suff: ((M + proj1_sig k1)%nat = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig k1)%nat (H5 k1))).
+suff: ((M + proj1_sig k1) = proj1_sig (exist (fun n : nat => (n < M + N)) (M + proj1_sig k1) (H5 k1))).
 move=> H15.
 rewrite H15.
 rewrite H14.
 reflexivity.
 reflexivity.
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
 rewrite - (proj2_sig (H12 k1)).
 rewrite H13.
 apply (proj2_sig (H12 k2)).
 move=> m.
 apply constructive_definite_description.
-apply (unique_existence (fun (x : {n : nat | (n < N)%nat}) => proj1_sig (g x) = proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m))))).
+apply (unique_existence (fun (x : {n : nat | (n < N)}) => proj1_sig (g x) = proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))))).
 apply conj.
-suff: (In nat (Im {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) g)) (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m))))).
+suff: (In nat (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) g)) (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))))).
 elim.
 move=> x H12 y H13.
 exists x.
 rewrite H13.
 reflexivity.
 rewrite (proj1 H11).
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0)) (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m))).
+apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0)) (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))).
 apply le_plus_l.
 reflexivity.
 move=> k1 k2 H12 H13.
@@ -4138,13 +4140,13 @@ rewrite {1} H14.
 apply (proj2 H11 k2 k1 H15).
 rewrite H13.
 apply H12.
-suff: (cardinal nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0))) N).
+suff: (cardinal nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0))) N).
 move=> H11.
-suff: (forall (m : nat), (m < N)%nat -> {k : nat | cardinal nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun (l : nat) => (l < k)%nat)) m /\ In nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) k}).
+suff: (forall (m : nat), (m < N) -> {k : nat | cardinal nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun (l : nat) => (l < k))) m /\ In nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) k}).
 move=> H12.
-suff: (forall (m : nat) (H : m < N), proj1_sig (H12 m H) < M)%nat.
+suff: (forall (m : nat) (H : m < N), proj1_sig (H12 m H) < M).
 move=> H13.
-exists (fun (k : {n : nat | (n < N)%nat}) => exist (fun (l : nat) => (l < M)%nat) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))).
+exists (fun (k : {n : nat | (n < N)}) => exist (fun (l : nat) => (l < M)) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))).
 apply conj.
 apply Extensionality_Ensembles.
 apply conj.
@@ -4156,24 +4158,24 @@ apply (proj2 (proj2_sig (H12 (proj1_sig x) (proj2_sig x)))).
 move=> m.
 elim.
 move=> x H14 y H15.
-suff: (exists (m : nat), (m < N)%nat /\ cardinal nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0))) (fun (l : nat) => (l < y)%nat)) m).
+suff: (exists (m : nat), (m < N) /\ cardinal nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0))) (fun (l : nat) => (l < y))) m).
 elim.
 move=> l H16.
-apply (Im_intro {n : nat | (n < N)%nat} nat (Full_set {n : nat | (n < N)%nat}) (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) (fun k : {n : nat | (n < N)%nat} => exist (fun (n : nat) => (n < M)%nat) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k)))) (exist (fun (n : nat) => (n < N)%nat) l (proj1 H16))).
-apply (Full_intro {n : nat | (n < N)%nat}).
-elim (le_or_lt y (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) (fun k : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M)%nat) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)%nat) l (proj1 H16)))).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) (fun k : {n : nat | (n < N)} => exist (fun (n : nat) => (n < M)) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k)))) (exist (fun (n : nat) => (n < N)) l (proj1 H16))).
+apply (Full_intro {n : nat | (n < N)}).
+elim (le_or_lt y (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) (fun k : {n : nat | (n < N)} => exist (fun n : nat => (n < M)) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)) l (proj1 H16)))).
 move=> H17.
-elim (le_lt_or_eq y (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) (fun k : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M)%nat) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)%nat) l (proj1 H16))) H17).
+elim (le_lt_or_eq y (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) (fun k : {n : nat | (n < N)} => exist (fun n : nat => (n < M)) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)) l (proj1 H16))) H17).
 move=> H18.
 apply False_ind.
 apply (lt_irrefl l).
-suff: (Included nat (Add nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)%nat)) y) (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16)))%nat))).
-apply (incl_card_le nat (Add nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)%nat)) y) (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16)))%nat)) (S l) l).
+suff: (Included nat (Add nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y))) y) (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16)))))).
+apply (incl_card_le nat (Add nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y))) y) (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16))))) (S l) l).
 apply card_add.
 apply (proj2 H16).
 move=> H19.
 apply (lt_irrefl y).
-suff: (forall (z : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)%nat)) z -> z < y)%nat.
+suff: (forall (z : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y))) z -> z < y).
 move=> H20.
 apply (H20 y H19).
 move=> z.
@@ -4193,7 +4195,7 @@ move=> k1.
 elim.
 apply Intersection_intro.
 rewrite H15.
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun (l : {n : nat | (n < M + N)%nat}) => (proj1_sig l >= M)%nat) (Basics.compose (fun (l : {n : nat | (n < M + N)%nat}) => proj1_sig l) (proj1_sig u0)) x).
+apply (Im_intro {n : nat | (n < M + N)} nat (fun (l : {n : nat | (n < M + N)}) => (proj1_sig l >= M)) (Basics.compose (fun (l : {n : nat | (n < M + N)}) => proj1_sig l) (proj1_sig u0)) x).
 apply H14.
 reflexivity.
 apply H18.
@@ -4201,14 +4203,14 @@ apply.
 move=> H17.
 apply False_ind.
 apply (lt_irrefl l).
-apply (incl_card_le nat (Add nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16)))%nat)) (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) (fun k : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M)%nat) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)%nat) l (proj1 H16)))) (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < y)%nat)) (S l) l).
+apply (incl_card_le nat (Add nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16))))) (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) (fun k : {n : nat | (n < N)} => exist (fun n : nat => (n < M)) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)) l (proj1 H16)))) (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < y))) (S l) l).
 apply card_add.
-apply (proj1 (proj2_sig (H12 (proj1_sig (exist (fun n : nat => n < N) l (proj1 H16))) (proj2_sig (exist (fun n : nat => n < N) l (proj1 H16))))))%nat.
+apply (proj1 (proj2_sig (H12 (proj1_sig (exist (fun n : nat => n < N) l (proj1 H16))) (proj2_sig (exist (fun n : nat => n < N) l (proj1 H16)))))).
 move=> H18.
-apply (lt_irrefl (Basics.compose (fun k : {n : nat | (n < M)%nat} => proj1_sig k) (fun k : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M)%nat) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)%nat) l (proj1 H16)))).
-suff: (forall (z : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16)))%nat)) z -> z < (Basics.compose (fun k : {n : nat | n < M} => proj1_sig k) (fun k : {n : nat | n < N} => exist (fun n : nat => n < M) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => n < N) l (proj1 H16))))%nat.
+apply (lt_irrefl (Basics.compose (fun k : {n : nat | (n < M)} => proj1_sig k) (fun k : {n : nat | (n < N)} => exist (fun n : nat => (n < M)) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => (n < N)) l (proj1 H16)))).
+suff: (forall (z : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l0 : nat => (l0 < proj1_sig (H12 l (proj1 H16))))) z -> z < (Basics.compose (fun k : {n : nat | n < M} => proj1_sig k) (fun k : {n : nat | n < N} => exist (fun n : nat => n < M) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => n < N) l (proj1 H16)))).
 move=> H19.
-apply (H19 (Basics.compose (fun k : {n : nat | n < M} => proj1_sig k) (fun k : {n : nat | n < N} => exist (fun n : nat => n < M) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => n < N) l (proj1 H16))) H18)%nat.
+apply (H19 (Basics.compose (fun k : {n : nat | n < M} => proj1_sig k) (fun k : {n : nat | n < N} => exist (fun n : nat => n < M) (proj1_sig (H12 (proj1_sig k) (proj2_sig k))) (H13 (proj1_sig k) (proj2_sig k))) (exist (fun n : nat => n < N) l (proj1 H16))) H18).
 move=> z.
 elim.
 move=> z0 H19 H20.
@@ -4230,16 +4232,16 @@ simpl.
 elim (proj2 (proj2_sig (H12 l (proj1 H16)))).
 move=> z H18 w H19.
 rewrite H19.
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun (l : {n : nat | (n < M + N)%nat}) => (proj1_sig l >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0)) z).
+apply (Im_intro {n : nat | (n < M + N)} nat (fun (l : {n : nat | (n < M + N)}) => (proj1_sig l >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0)) z).
 apply H18.
 reflexivity.
 apply H17.
 simpl.
-elim (finite_cardinal nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)%nat))).
+elim (finite_cardinal nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)))).
 move=> z H16.
 exists z.
 apply conj.
-apply (incl_st_card_lt nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)%nat)) z H16 (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) N H11).
+apply (incl_st_card_lt nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y))) z H16 (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) N H11).
 apply conj.
 move=> w.
 elim.
@@ -4247,20 +4249,20 @@ move=> w0 H17 H18.
 apply H17.
 move=> H17.
 apply (lt_irrefl y).
-suff: (forall (w : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y)%nat)) w -> w < y)%nat.
+suff: (forall (w : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < y))) w -> w < y).
 move=> H18.
 apply (H18 y).
 rewrite H17.
 rewrite H15.
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0)) x H14).
+apply (Im_intro {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0)) x H14).
 reflexivity.
 move=> w.
 elim.
 move=> w0 H18 H19.
 apply H19.
 apply H16.
-apply (Finite_downward_closed nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0)))).
-apply (cardinal_finite nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) N H11).
+apply (Finite_downward_closed nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0)))).
+apply (cardinal_finite nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) N H11).
 move=> z.
 elim.
 move=> w H16 H17.
@@ -4272,7 +4274,7 @@ move=> H15.
 apply False_ind.
 apply (lt_irrefl (proj1_sig p)).
 apply (le_trans (S (proj1_sig p)) (proj1_sig q) (proj1_sig p) H14).
-apply (incl_card_le nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < proj1_sig (H12 (proj1_sig q) (proj2_sig q)))%nat)) (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < proj1_sig (H12 (proj1_sig p) (proj2_sig p)))%nat))).
+apply (incl_card_le nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < proj1_sig (H12 (proj1_sig q) (proj2_sig q))))) (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < proj1_sig (H12 (proj1_sig p) (proj2_sig p)))))).
 apply (proj1 (proj2_sig (H12 (proj1_sig q) (proj2_sig q)))).
 apply (proj1 (proj2_sig (H12 (proj1_sig p) (proj2_sig p)))).
 move=> m.
@@ -4289,11 +4291,11 @@ rewrite H15.
 apply (H10 x H14).
 elim.
 move=> H12.
-elim (min_nat_get (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0)))).
+elim (min_nat_get (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0)))).
 move=> l H13.
 exists l.
 apply conj.
-suff: ((Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0))) (fun (m : nat) => (m < l)%nat)) = Empty_set nat).
+suff: ((Intersection nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0))) (fun (m : nat) => (m < l))) = Empty_set nat).
 move=> H14.
 rewrite H14.
 apply card_empty.
@@ -4310,10 +4312,10 @@ apply (proj1 H13).
 suff: (exists (n : nat), S n = N).
 elim.
 move=> n H13.
-apply (cardinal_elim nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0))) (S n)).
+apply (cardinal_elim nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0))) (S n)).
 rewrite H13.
 apply H11.
-suff: (0 < N)%nat.
+suff: (0 < N).
 elim N.
 move=> H13.
 apply False_ind.
@@ -4325,17 +4327,17 @@ apply H12.
 move=> m H12 H13.
 elim (H12 (le_trans (S m) (S (S m)) N (le_S (S m) (S m) (le_n (S m))) H13)).
 move=> k H14.
-elim (min_nat_get (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun (l : nat) => (k < l)%nat))).
+elim (min_nat_get (Intersection nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun (l : nat) => (k < l)))).
 move=> s H15.
 exists s.
 apply conj.
-suff: ((Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun (k0 : {n : nat | (n < M + N)%nat}) => (proj1_sig k0 >= M)%nat) (Basics.compose (fun (k0 : {n : nat | (n < M + N)%nat}) => proj1_sig k0) (proj1_sig u0))) (fun (l : nat) => (l < s)%nat)) = Add nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < k)%nat)) k).
+suff: ((Intersection nat (Im {n : nat | (n < M + N)} nat (fun (k0 : {n : nat | (n < M + N)}) => (proj1_sig k0 >= M)) (Basics.compose (fun (k0 : {n : nat | (n < M + N)}) => proj1_sig k0) (proj1_sig u0))) (fun (l : nat) => (l < s))) = Add nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < k))) k).
 move=> H16.
 rewrite H16.
 apply card_add.
 apply (proj1 H14).
 move=> H17.
-suff: (forall (w : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < k)%nat)) w -> (w < k)%nat).
+suff: (forall (w : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < k))) w -> (w < k)).
 move=> H18.
 apply (lt_irrefl k).
 apply (H18 k H17).
@@ -4392,12 +4394,12 @@ apply H16.
 apply NNPP.
 move=> H15.
 apply (le_not_lt N (S m)).
-apply (incl_card_le nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0))) (Add nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < k)%nat)) k)).
+apply (incl_card_le nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0))) (Add nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (fun l : nat => (l < k))) k)).
 apply H11.
 apply card_add.
 apply (proj1 H14).
 move=> H16.
-suff: (forall (w : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun k0 : {n : nat | (n < M + N)%nat} => (proj1_sig k0 >= M)%nat) (Basics.compose (fun k0 : {n : nat | (n < M + N)%nat} => proj1_sig k0) (proj1_sig u0))) (fun l : nat => (l < k)%nat)) w -> (w < k)%nat).
+suff: (forall (w : nat), In nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun k0 : {n : nat | (n < M + N)} => (proj1_sig k0 >= M)) (Basics.compose (fun k0 : {n : nat | (n < M + N)} => proj1_sig k0) (proj1_sig u0))) (fun l : nat => (l < k))) w -> (w < k)).
 move=> H17.
 apply False_ind.
 apply (lt_irrefl k).
@@ -4422,38 +4424,38 @@ apply (In_singleton nat k).
 move=> H17.
 apply False_ind.
 apply H15.
-apply (Inhabited_intro nat (Intersection nat (Im {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0))) (fun l : nat => (k < l)%nat)) w).
+apply (Inhabited_intro nat (Intersection nat (Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0))) (fun l : nat => (k < l))) w).
 apply Intersection_intro.
 apply H16.
 apply H17.
 apply H13.
 apply (CardinalSigSame nat).
 apply CountCardinalBijective.
-suff: (forall (m : {n : nat | (n < N)%nat}), In nat (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (proj1_sig (proj1_sig u0 (exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig m)%nat (H5 m))))).
+suff: (forall (m : {n : nat | (n < N)}), In nat (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (proj1_sig (proj1_sig u0 (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig m) (H5 m))))).
 move=> H11.
-exists (fun (m : {n : nat | (n < N)%nat}) => exist (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (proj1_sig (proj1_sig u0 (exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig m)%nat (H5 m)))) (H11 m)).
+exists (fun (m : {n : nat | (n < N)}) => exist (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (proj1_sig (proj1_sig u0 (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig m) (H5 m)))) (H11 m)).
 apply InjSurjBij.
 move=> m1 m2 H12.
 apply sig_map.
 apply (plus_reg_l (proj1_sig m1) (proj1_sig m2) M).
-suff: ((exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1)) = (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig m2)%nat (H5 m2))).
+suff: ((exist (fun s : nat => (s < M + N)) (M + proj1_sig m1) (H5 m1)) = (exist (fun s : nat => (s < M + N)) (M + proj1_sig m2) (H5 m2))).
 move=> H13.
-suff: ((M + proj1_sig m1)%nat = proj1_sig (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1))).
+suff: ((M + proj1_sig m1) = proj1_sig (exist (fun s : nat => (s < M + N)) (M + proj1_sig m1) (H5 m1))).
 move=> H14.
 rewrite H14.
 rewrite H13.
 reflexivity.
 reflexivity.
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
-suff: (proj1_sig (proj1_sig u0 (exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1))) = proj1_sig (exist (Im {n : nat | (n < M + N)%nat} nat (fun k : {n : nat | (n < M + N)%nat} => (proj1_sig k >= M)%nat) (Basics.compose (fun k : {n : nat | (n < M + N)%nat} => proj1_sig k) (proj1_sig u0))) (proj1_sig (proj1_sig u0 (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1)))) (H11 m1))).
+suff: (proj1_sig (proj1_sig u0 (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig m1) (H5 m1))) = proj1_sig (exist (Im {n : nat | (n < M + N)} nat (fun k : {n : nat | (n < M + N)} => (proj1_sig k >= M)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (proj1_sig u0))) (proj1_sig (proj1_sig u0 (exist (fun s : nat => (s < M + N)) (M + proj1_sig m1) (H5 m1)))) (H11 m1))).
 move=> H13.
 rewrite H13.
 rewrite H12.
 reflexivity.
 reflexivity.
 move=> k.
-suff: (exists (x : {n : nat | (n < N)%nat}), (proj1_sig (proj1_sig u0 (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig x)%nat (H5 x)))) = proj1_sig k).
+suff: (exists (x : {n : nat | (n < N)}), (proj1_sig (proj1_sig u0 (exist (fun s : nat => (s < M + N)) (M + proj1_sig x) (H5 x)))) = proj1_sig k).
 elim.
 move=> x H12.
 exists x.
@@ -4463,14 +4465,14 @@ elim (proj2_sig k).
 move=> x H12 y H13.
 exists (proj1_sig (blockdividesub M N x H12)).
 rewrite H13.
-suff: ((exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (blockdividesub M N x H12)))%nat (H5 (proj1_sig (blockdividesub M N x H12)))) = x).
+suff: ((exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (blockdividesub M N x H12))) (H5 (proj1_sig (blockdividesub M N x H12)))) = x).
 move=> H14.
 rewrite H14.
 reflexivity.
 apply sig_map.
 apply (proj2_sig (blockdividesub M N x H12)).
 move=> m.
-apply (Im_intro {n : nat | (n < M + N)%nat} nat (fun (k : {n : nat | (n < M + N)%nat}) => (proj1_sig k >= M)%nat) (Basics.compose (fun (k : {n : nat | (n < M + N)%nat}) => proj1_sig k) (proj1_sig u0)) (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig m)%nat (H5 m))).
+apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0)) (exist (fun s : nat => (s < M + N)) (M + proj1_sig m) (H5 m))).
 apply le_plus_l.
 reflexivity.
 move=> m H10.
@@ -4493,7 +4495,7 @@ apply False_ind.
 apply (le_not_lt M (proj1_sig (proj1_sig u0 m)) H11 H12).
 apply.
 move=> P H7.
-apply (Full_intro (Permutation (M + N)%nat) P).
+apply (Full_intro (Permutation (M + N)) P).
 move=> x.
 elim (excluded_middle_informative (Injective (fst x))).
 move=> H6.
@@ -4501,10 +4503,10 @@ elim (proj2_sig (fst (snd x))).
 move=> fsti H7.
 elim (proj2_sig (snd (snd x))).
 move=> sndi H8.
-exists ((fun (k : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)%nat) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (sndi (proj1_sig (blockdividesub M N k b)))))
-  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)%nat}, exist (fun s : nat => (s < M)%nat) (proj1_sig k) b = fst x l) with
-    | left c => exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) H6 c))))%nat (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) b) H6 c))))
+exists ((fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (sndi (proj1_sig (blockdividesub M N k b)))))
+  | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst x l) with
+    | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) H6 c)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H6 c))))
     | right _ => k
   end
 end)).
@@ -4520,17 +4522,17 @@ simpl.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10 (proj2_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9)))))).
 move=> H10.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10 = fst x l)).
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10) H6 H11)) = (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))%nat.
+suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10) H6 H11)) = (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9)))).
 move=> H12.
 rewrite H12.
 rewrite (proj1 H7).
 apply (proj2_sig (blockdividesub M N k H9)).
 apply H6.
-rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10) H6 H11))%nat.
+rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10) H6 H11)).
 apply sig_map.
 reflexivity.
 move=> H11.
@@ -4540,25 +4542,25 @@ exists (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))).
 apply sig_map.
 reflexivity.
 move=> H9.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig k) H9 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig k) H9 = fst x l)).
 move=> H10.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H9) H6 H10))))).
+elim (le_lt_dec M (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))).
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H9) H6 H10))))) H11)) = (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11)) = (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))).
 move=> H12.
 rewrite H12.
 rewrite (proj1 H8).
-rewrite - (proj2_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)%nat) (proj1_sig k) H9) H6 H10)).
+rewrite - (proj2_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) H9) H6 H10)).
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H9) H6 H10))))) H11))) (proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H9) H6 H10)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))%nat (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig k) H9) H6 H10))))) H11)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11))) (proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10)))) M).
+apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11)).
 move=> H11.
 apply False_ind.
-apply (le_not_lt M (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))%nat).
+apply (le_not_lt M (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))).
 apply le_plus_l.
 apply H11.
 move=> H10.
@@ -4567,7 +4569,7 @@ move=> H11.
 apply False_ind.
 apply (le_not_lt M (proj1_sig k) H11 H9).
 move=> H11.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig k) H11 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig k) H11 = fst x l)).
 move=> H12.
 apply False_ind.
 apply H10.
@@ -4590,17 +4592,17 @@ move=> H10.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10 (proj2_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9)))))).
 move=> H10.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10 = fst x l)).
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10) H6 H11)) = (sndi (proj1_sig (blockdividesub M N y H9))))%nat.
+suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10) H6 H11)) = (sndi (proj1_sig (blockdividesub M N y H9)))).
 move=> H12.
 rewrite H12.
 rewrite (proj2 H8).
 apply (proj2_sig (blockdividesub M N y H9)).
 apply H6.
-rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10) H6 H11)).
+rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10) H6 H11)).
 apply sig_map.
 reflexivity.
 move=> H11.
@@ -4610,25 +4612,25 @@ exists (sndi (proj1_sig (blockdividesub M N y H9))).
 apply sig_map.
 reflexivity.
 move=> H9.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig y) H9 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig y) H9 = fst x l)).
 move=> H10.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig y) H9) H6 H10))))).
+elim (le_lt_dec M (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))).
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10))))%nat (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig y) H9) H6 H10))))) H11)) = (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10))))%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))) H11)) = (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))).
 move=> H12.
 rewrite H12.
 rewrite (proj2 H7).
-rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig y) H9) H6 H10)).
+rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10)).
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)%nat) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10))))%nat (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig y) H9) H6 H10))))) H11))) (proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)%nat) (proj1_sig y) H9) H6 H10)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun (s : nat) => (s < M + N)%nat) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => s < M) (proj1_sig y) H9) H6 H10))))%nat (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)%nat) (proj1_sig y) H9) H6 H10))))) H11)).
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))) H11))) (proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10)))) M).
+apply (proj2_sig (blockdividesub M N (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig y) H9) H6 H10))))) H11)).
 move=> H11.
 apply False_ind.
-apply (le_not_lt M (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10))))%nat).
+apply (le_not_lt M (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10))))).
 apply le_plus_l.
 apply H11.
 move=> H10.
@@ -4637,7 +4639,7 @@ move=> H11.
 apply False_ind.
 apply (le_not_lt M (proj1_sig y) H11 H9).
 move=> H11.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)%nat}), exist (fun s : nat => (s < M)%nat) (proj1_sig y) H11 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig y) H11 = fst x l)).
 move=> H12.
 apply False_ind.
 apply H10.
@@ -4652,7 +4654,7 @@ apply proof_irrelevance.
 move=> H12.
 reflexivity.
 move=> H6.
-exists (fun k : {n : nat | (n < M + N)%nat} => k).
+exists (fun k : {n : nat | (n < M + N)} => k).
 apply conj.
 move=> y.
 reflexivity.
@@ -4661,11 +4663,11 @@ reflexivity.
 move=> l.
 apply (plus_lt_compat_l (proj1_sig l) N M (proj2_sig l)).
 move=> l.
-apply (le_trans (S (proj1_sig l)) M (M + N)%nat (proj2_sig l)).
+apply (le_trans (S (proj1_sig l)) M (M + N) (proj2_sig l)).
 apply le_plus_l.
 move=> p k H3 H4.
 apply constructive_definite_description.
-apply (unique_existence (fun (l : {n : nat | (n < N)%nat}) => k = p l)).
+apply (unique_existence (fun (l : {n : nat | (n < N)}) => k = p l)).
 apply conj.
 apply H4.
 move=> l1 l2 H5 H6.
@@ -4673,12 +4675,12 @@ apply H3.
 rewrite - H5.
 apply H6.
 rewrite - H1.
-suff: (forall (m : nat), (m <= N)%nat -> Determinant f N (Mmult f N M N A B) = Fmul f (PowF f (Fopp f (FI f)) m) (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match (le_lt_dec m (proj1_sig x)) with
+suff: (forall (m : nat), (m <= N) -> Determinant f N (Mmult f N M N A B) = Fmul f (PowF f (Fopp f (FI f)) m) (Determinant f N (fun (x y : {n : nat | (n < N)}) => match (le_lt_dec m (proj1_sig x)) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
 end))).
 move=> H2.
-suff: ((Mopp f N N (Mmult f N M N A B)) = (fun (x y : {n : nat | (n < N)%nat}) => match (le_lt_dec N (proj1_sig x)) with
+suff: ((Mopp f N N (Mmult f N M N A B)) = (fun (x y : {n : nat | (n < N)}) => match (le_lt_dec N (proj1_sig x)) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
 end)).
@@ -4697,7 +4699,7 @@ move=> H3.
 reflexivity.
 elim.
 move=> H2.
-suff: ((Mmult f N M N A B) = (fun (x y : {n : nat | (n < N)%nat}) => match (le_lt_dec O (proj1_sig x)) with
+suff: ((Mmult f N M N A B) = (fun (x y : {n : nat | (n < N)}) => match (le_lt_dec O (proj1_sig x)) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
 end)).
@@ -4716,10 +4718,10 @@ move=> H3.
 apply False_ind.
 apply (le_not_lt O (proj1_sig x) (le_0_n (proj1_sig x)) H3).
 move=> m H2 H3.
-suff: (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match le_lt_dec (S m) (proj1_sig x) with
+suff: (Determinant f N (fun (x y : {n : nat | (n < N)}) => match le_lt_dec (S m) (proj1_sig x) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
-end) = Fmul f (Fopp f (FI f)) (Determinant f N (fun (x y : {n : nat | (n < N)%nat}) => match le_lt_dec m (proj1_sig x) with
+end) = Fmul f (Fopp f (FI f)) (Determinant f N (fun (x y : {n : nat | (n < N)}) => match le_lt_dec m (proj1_sig x) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
 end))).
@@ -4732,14 +4734,14 @@ rewrite (Fmul_opp_opp f (FI f)).
 rewrite (Fmul_I_r f).
 rewrite (Fmul_I_r f).
 apply (H2 (le_trans m (S m) N (le_S m m (le_n m)) H3)).
-rewrite - (DeterminantMultiLinearityHMult f N (fun (x y : {n : nat | (n < N)%nat}) => match (le_lt_dec m (proj1_sig x)) with
+rewrite - (DeterminantMultiLinearityHMult f N (fun (x y : {n : nat | (n < N)}) => match (le_lt_dec m (proj1_sig x)) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
-end) (exist (fun (k : nat) => (k < N)%nat) m H3) (Fopp f (FI f))).
-suff: ((fun (x y : {n : nat | (n < N)%nat}) => match le_lt_dec (S m) (proj1_sig x) with
+end) (exist (fun (k : nat) => (k < N)) m H3) (Fopp f (FI f))).
+suff: ((fun (x y : {n : nat | (n < N)}) => match le_lt_dec (S m) (proj1_sig x) with
   | left _ => Mmult f N M N A B x y
   | right _ => Fopp f (Mmult f N M N A B x y)
-end) = (fun (x y : {n : nat | (n < N)%nat}) => match Nat.eq_dec (proj1_sig x) (proj1_sig (exist (fun k : nat => (k < N)%nat) m H3)) with
+end) = (fun (x y : {n : nat | (n < N)}) => match Nat.eq_dec (proj1_sig x) (proj1_sig (exist (fun k : nat => (k < N)) m H3)) with
   | left _ => (Fmul f (Fopp f (FI f)) match le_lt_dec m (proj1_sig x) with
     | left _ => Mmult f N M N A B x y
     | right _ => Fopp f (Mmult f N M N A B x y)
@@ -4758,7 +4760,7 @@ apply functional_extensionality.
 move=> y.
 elim (le_lt_dec (S m) (proj1_sig x)).
 move=> H4.
-elim (Nat.eq_dec (proj1_sig x) (proj1_sig (exist (fun k : nat => (k < N)%nat) m H3))).
+elim (Nat.eq_dec (proj1_sig x) (proj1_sig (exist (fun k : nat => (k < N)) m H3))).
 move=> H5.
 apply False_ind.
 apply (le_not_lt (proj1_sig x) m).
@@ -4774,7 +4776,7 @@ apply False_ind.
 apply (lt_irrefl m).
 apply (lt_trans m (proj1_sig x) m H4 H6).
 move=> H4.
-elim (Nat.eq_dec (proj1_sig x) (proj1_sig (exist (fun k : nat => (k < N)%nat) m H3))).
+elim (Nat.eq_dec (proj1_sig x) (proj1_sig (exist (fun k : nat => (k < N)) m H3))).
 move=> H5.
 elim (le_lt_dec m (proj1_sig x)).
 move=> H6.
@@ -4839,19 +4841,19 @@ rewrite H4.
 rewrite (Mplus_comm f M M).
 rewrite (Mplus_O_l f M M).
 unfold Determinant.
-suff: (forall (m : {n : nat | (n < N)%nat}), (M + proj1_sig m < M + N)%nat).
+suff: (forall (m : {n : nat | (n < N)}), (M + proj1_sig m < M + N)).
 move=> H5.
-suff: (forall (P : Permutation N), Bijective (fun (m : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+suff: (forall (P : Permutation N), Bijective (fun (m : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
   | right _ => m
 end)).
 move=> H6.
-rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (Permutation N) (Permutation (M + N)) (fun (P : (Permutation N)) => exist Bijective (fun (m : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (Permutation N) (Permutation (M + N)) (fun (P : (Permutation N)) => exist Bijective (fun (m : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
   | right _ => m
 end) (H6 P)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N)))).
-rewrite (MySumF2O (Permutation (M + N)) (FiniteIntersection (Permutation (M + N)) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N))) (Complement (Permutation (M + N)) (proj1_sig (FiniteIm (Permutation N) (Permutation (M + N)) (fun P : Permutation N => exist Bijective (fun m : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+rewrite (MySumF2O (Permutation (M + N)) (FiniteIntersection (Permutation (M + N)) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N))) (Complement (Permutation (M + N)) (proj1_sig (FiniteIm (Permutation N) (Permutation (M + N)) (fun P : Permutation N => exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
   | right _ => m
 end) (H6 P)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))))).
 rewrite (CM_O_r (FPCM f)).
@@ -4859,18 +4861,18 @@ rewrite - (MySumF2BijectiveSame2 (Permutation N) (Permutation (M + N))).
 unfold Basics.compose.
 apply MySumF2Same.
 move=> P H7.
-suff: (PermutationParity N P = PermutationParity (M + N) (exist Bijective (fun m : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+suff: (PermutationParity N P = PermutationParity (M + N) (exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
   | right _ => m
 end) (H6 P))).
 move=> H8.
 rewrite H8.
 apply (Fmul_eq_compat_l f).
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteIm {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (fun (m : {n : nat | (n < N)%nat}) => exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))) (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N)))).
-rewrite (MySumF2O {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)%nat} (proj1_sig (FiniteIm {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (fun m : {n : nat | (n < N)%nat} => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N))))))).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteIm {n : nat | (n < N)} {n : nat | (n < M + N)} (fun (m : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))) (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N)))).
+rewrite (MySumF2O {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)} (proj1_sig (FiniteIm {n : nat | (n < N)} {n : nat | (n < M + N)} (fun m : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig m) (H5 m)) (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N))))))).
 rewrite (CM_O_r (FMCM f)).
-rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat}).
-apply (MySumF2Same {n : nat | (n < N)%nat} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)%nat}) (CountFinite N)) (FMCM f)).
+rewrite - (MySumF2BijectiveSame2 {n : nat | (n < N)} {n : nat | (n < M + N)}).
+apply (MySumF2Same {n : nat | (n < N)} (exist (Finite (Count N)) (Full_set {n : nat | (n < N)}) (CountFinite N)) (FMCM f)).
 move=> x H9.
 unfold Basics.compose.
 simpl.
@@ -4882,24 +4884,24 @@ move=> H10.
 simpl.
 elim (le_lt_dec M (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) (@proj1_sig (forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N)) (fun f0 : forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N) => @Bijective (@sig nat (fun n : nat => lt n N)) (@sig nat (fun n : nat => lt n N)) f0) P (@proj1_sig (@sig nat (fun n : nat => lt n N)) (fun y : @sig nat (fun n : nat => lt n N) => @eq nat (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) y)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) x))) (blockdividesub M N (@exist nat (fun n : nat => lt n (Init.Nat.add M N)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) x)) (H5 x)) H10)))))).
 move=> H11.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig x)%nat (H5 x)) H10)) = x).
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10)) = x).
 move=> H12.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig x)%nat (H5 x)) H10))))) H11)) = proj1_sig P x).
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))))) H11)) = proj1_sig P x).
 move=> H13.
 rewrite H13.
 rewrite H12.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig x)%nat (H5 x)) H10))))) H11))) (proj1_sig (proj1_sig P x)) M).
-rewrite (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))) H11))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))))) H11))) (proj1_sig (proj1_sig P x)) M).
+rewrite (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))) H11)).
 rewrite H12.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig x)%nat (H5 x)) H10))) (proj1_sig x) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))) (proj1_sig x) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)).
 move=> H11.
 apply False_ind.
-apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))))%nat.
+apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))).
 apply le_plus_l.
 apply H11.
 move=> H10.
@@ -4908,7 +4910,7 @@ apply (le_not_lt M (M + proj1_sig x) (le_plus_l M (proj1_sig x)) H10).
 move=> u1 u2 H9 H10 H11.
 apply sig_map.
 apply (plus_reg_l (proj1_sig u1) (proj1_sig u2) M).
-suff: ((M + proj1_sig u1)%nat = proj1_sig (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig u1)%nat (H5 u1))).
+suff: ((M + proj1_sig u1) = proj1_sig (exist (fun n : nat => (n < M + N)) (M + proj1_sig u1) (H5 u1))).
 move=> H12.
 rewrite H12.
 rewrite H11.
@@ -4923,8 +4925,8 @@ elim H9.
 move=> u0 H10 H11 H12.
 apply False_ind.
 apply H10.
-apply (Im_intro {n : nat | (n < N)%nat} {n : nat | (n < M + N)%nat} (Full_set {n : nat | (n < N)%nat}) (fun (m : {n : nat | (n < N)%nat}) => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) (proj1_sig (blockdividesub M N u0 H12))).
-apply (Full_intro {n : nat | (n < N)%nat}).
+apply (Im_intro {n : nat | (n < N)} {n : nat | (n < M + N)} (Full_set {n : nat | (n < N)}) (fun (m : {n : nat | (n < N)}) => exist (fun n : nat => (n < M + N)) (M + proj1_sig m) (H5 m)) (proj1_sig (blockdividesub M N u0 H12))).
+apply (Full_intro {n : nat | (n < N)}).
 apply sig_map.
 simpl.
 rewrite (proj2_sig (blockdividesub M N u0 H12)).
@@ -4936,7 +4938,7 @@ apply False_ind.
 apply (le_not_lt M (proj1_sig u) H11 H10).
 move=> H11.
 unfold MI.
-elim (Nat.eq_dec (proj1_sig (exist (fun n : nat => (n < M)%nat) (proj1_sig u) H10)) (proj1_sig (exist (fun n : nat => (n < M)%nat) (proj1_sig u) H11))).
+elim (Nat.eq_dec (proj1_sig (exist (fun n : nat => (n < M)) (proj1_sig u) H10)) (proj1_sig (exist (fun n : nat => (n < M)) (proj1_sig u) H11))).
 move=> H12.
 reflexivity.
 move=> H12.
@@ -4948,14 +4950,14 @@ rewrite H13.
 reflexivity.
 apply proof_irrelevance.
 move=> m H9.
-apply (Full_intro {n : nat | (n < M + N)%nat} m).
+apply (Full_intro {n : nat | (n < M + N)} m).
 unfold PermutationParity.
 simpl.
-rewrite (MySumF2Included ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (FiniteIm ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (fun (m : ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat})) => (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (fst m))%nat (H5 (fst m)),exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (snd m))%nat (H5 (snd m)))) (exist (Finite ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat})) (fun xy : {n : nat | (n < N)%nat} * {n : nat | (n < N)%nat} => (proj1_sig (fst xy) < proj1_sig (snd xy))%nat) (PermutationParitySub N)))).
-rewrite (MySumF2O ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (FiniteIntersection ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (exist (Finite ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat})) (fun (xy : {n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) => (proj1_sig (fst xy) < proj1_sig (snd xy))%nat) (PermutationParitySub (M + N))) (Complement ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (proj1_sig (FiniteIm ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (fun m : {n : nat | (n < N)%nat} * {n : nat | (n < N)%nat} => (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (fst m))%nat (H5 (fst m)), exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (snd m))%nat (H5 (snd m)))) (exist (Finite ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat})) (fun xy : {n : nat | (n < N)%nat} * {n : nat | (n < N)%nat} => (proj1_sig (fst xy) < proj1_sig (snd xy))%nat) (PermutationParitySub N))))))).
+rewrite (MySumF2Included ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (FiniteIm ({n : nat | (n < N)} * {n : nat | (n < N)}) ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (fun (m : ({n : nat | (n < N)} * {n : nat | (n < N)})) => (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (fst m)) (H5 (fst m)),exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (snd m)) (H5 (snd m)))) (exist (Finite ({n : nat | (n < N)} * {n : nat | (n < N)})) (fun xy : {n : nat | (n < N)} * {n : nat | (n < N)} => (proj1_sig (fst xy) < proj1_sig (snd xy))) (PermutationParitySub N)))).
+rewrite (MySumF2O ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (FiniteIntersection ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (exist (Finite ({n : nat | (n < M + N)} * {n : nat | (n < M + N)})) (fun (xy : {n : nat | (n < M + N)} * {n : nat | (n < M + N)}) => (proj1_sig (fst xy) < proj1_sig (snd xy))) (PermutationParitySub (M + N))) (Complement ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (proj1_sig (FiniteIm ({n : nat | (n < N)} * {n : nat | (n < N)}) ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (fun m : {n : nat | (n < N)} * {n : nat | (n < N)} => (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst m)) (H5 (fst m)), exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd m)) (H5 (snd m)))) (exist (Finite ({n : nat | (n < N)} * {n : nat | (n < N)})) (fun xy : {n : nat | (n < N)} * {n : nat | (n < N)} => (proj1_sig (fst xy) < proj1_sig (snd xy))) (PermutationParitySub N))))))).
 rewrite CM_O_r.
-rewrite - (MySumF2BijectiveSame2 ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat})).
-apply (MySumF2Same ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) (exist (Finite ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat})) (fun (xy : {n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) => (proj1_sig (fst xy) < proj1_sig (snd xy))%nat) (PermutationParitySub N)) ParityXORCM).
+rewrite - (MySumF2BijectiveSame2 ({n : nat | (n < N)} * {n : nat | (n < N)}) ({n : nat | (n < M + N)} * {n : nat | (n < M + N)})).
+apply (MySumF2Same ({n : nat | (n < N)} * {n : nat | (n < N)}) (exist (Finite ({n : nat | (n < N)} * {n : nat | (n < N)})) (fun (xy : {n : nat | (n < N)} * {n : nat | (n < N)}) => (proj1_sig (fst xy) < proj1_sig (snd xy))) (PermutationParitySub N)) ParityXORCM).
 move=> xy H8.
 unfold Basics.compose.
 simpl.
@@ -4964,15 +4966,15 @@ move=> H9.
 elim (le_lt_dec M (M + proj1_sig (snd xy))).
 move=> H10.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)) = fst xy)%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)) = fst xy).
 move=> H11.
 rewrite H11.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)) = snd xy)%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)) = snd xy).
 move=> H12.
 rewrite H12.
-elim (excluded_middle_informative (proj1_sig (proj1_sig P (fst xy)) < proj1_sig (proj1_sig P (snd xy)))%nat).
+elim (excluded_middle_informative (proj1_sig (proj1_sig P (fst xy)) < proj1_sig (proj1_sig P (snd xy)))).
 move=> H13.
-elim (excluded_middle_informative (M + proj1_sig (proj1_sig P (fst xy)) < M + proj1_sig (proj1_sig P (snd xy)))%nat).
+elim (excluded_middle_informative (M + proj1_sig (proj1_sig P (fst xy)) < M + proj1_sig (proj1_sig P (snd xy)))).
 move=> H14.
 reflexivity.
 move=> H14.
@@ -4981,7 +4983,7 @@ apply H14.
 apply plus_lt_compat_l.
 apply H13.
 move=> H13.
-elim (excluded_middle_informative (M + proj1_sig (proj1_sig P (fst xy)) < M + proj1_sig (proj1_sig P (snd xy)))%nat).
+elim (excluded_middle_informative (M + proj1_sig (proj1_sig P (fst xy)) < M + proj1_sig (proj1_sig P (snd xy)))).
 move=> H14.
 apply False_ind.
 apply H13.
@@ -4989,11 +4991,11 @@ apply (plus_lt_reg_l (proj1_sig (proj1_sig P (fst xy))) (proj1_sig (proj1_sig P 
 move=> H14.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (snd xy))%nat (H5 (snd xy))) H10))) (proj1_sig (snd xy)) M)%nat.
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10))) (proj1_sig (snd xy)) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (fst xy))%nat (H5 (fst xy))) H9))) (proj1_sig (fst xy)) M)%nat.
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9))) (proj1_sig (fst xy)) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)).
 move=> H10.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig (snd xy)) (le_plus_l M (proj1_sig (snd xy))) H10).
@@ -5004,7 +5006,7 @@ move=> u1 u2 H8 H9 H10.
 apply injective_projections.
 apply sig_map.
 apply (plus_reg_l (proj1_sig (fst u1)) (proj1_sig (fst u2)) M).
-suff: ((M + proj1_sig (fst u1))%nat = proj1_sig (fst (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (fst u1))%nat (H5 (fst u1)), exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (snd u1))%nat (H5 (snd u1))))).
+suff: ((M + proj1_sig (fst u1)) = proj1_sig (fst (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst u1)) (H5 (fst u1)), exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd u1)) (H5 (snd u1))))).
 move=> H11.
 rewrite H11.
 rewrite H10.
@@ -5012,7 +5014,7 @@ reflexivity.
 reflexivity.
 apply sig_map.
 apply (plus_reg_l (proj1_sig (snd u1)) (proj1_sig (snd u2)) M).
-suff: ((M + proj1_sig (snd u1))%nat = proj1_sig (snd (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (fst u1))%nat (H5 (fst u1)), exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (snd u1))%nat (H5 (snd u1))))).
+suff: ((M + proj1_sig (snd u1)) = proj1_sig (snd (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst u1)) (H5 (fst u1)), exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd u1)) (H5 (snd u1))))).
 move=> H11.
 rewrite H11.
 rewrite H10.
@@ -5025,7 +5027,7 @@ elim H8.
 move=> u0 H9 H10 H11 H12.
 apply False_ind.
 apply H9.
-apply (Im_intro ({n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) ({n : nat | (n < M + N)%nat} * {n : nat | (n < M + N)%nat}) (fun (xy : {n : nat | (n < N)%nat} * {n : nat | (n < N)%nat}) => (proj1_sig (fst xy) < proj1_sig (snd xy))%nat) (fun m : {n : nat | (n < N)%nat} * {n : nat | (n < N)%nat} => (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (fst m))%nat (H5 (fst m)), exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (snd m))%nat (H5 (snd m)))) (proj1_sig (blockdividesub M N (fst u0) H12), proj1_sig (blockdividesub M N (snd u0) H11))).
+apply (Im_intro ({n : nat | (n < N)} * {n : nat | (n < N)}) ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (fun (xy : {n : nat | (n < N)} * {n : nat | (n < N)}) => (proj1_sig (fst xy) < proj1_sig (snd xy))) (fun m : {n : nat | (n < N)} * {n : nat | (n < N)} => (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst m)) (H5 (fst m)), exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd m)) (H5 (snd m)))) (proj1_sig (blockdividesub M N (fst u0) H12), proj1_sig (blockdividesub M N (snd u0) H11))).
 apply (plus_lt_reg_l (proj1_sig (proj1_sig (blockdividesub M N (fst u0) H12))) (proj1_sig (proj1_sig (blockdividesub M N (snd u0) H11))) M).
 rewrite (proj2_sig (blockdividesub M N (fst u0) H12)).
 rewrite (proj2_sig (blockdividesub M N (snd u0) H11)).
@@ -5046,17 +5048,17 @@ apply (le_not_lt M (proj1_sig (fst u0)) H12 (lt_trans (proj1_sig (fst u0)) (proj
 elim (le_lt_dec M (proj1_sig (snd u))).
 move=> H9 H10.
 simpl.
-elim (excluded_middle_informative (proj1_sig (fst u) < M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (snd u) H9))))%nat).
+elim (excluded_middle_informative (proj1_sig (fst u) < M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (snd u) H9))))).
 move=> H11.
 reflexivity.
 move=> H11.
 apply False_ind.
 apply H11.
-apply (le_trans (S (proj1_sig (fst u))) M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (snd u) H9))))%nat).
+apply (le_trans (S (proj1_sig (fst u))) M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (snd u) H9))))).
 apply H10.
 apply le_plus_l.
 move=> H9 H10.
-elim (excluded_middle_informative (proj1_sig (fst u) < proj1_sig (snd u)))%nat.
+elim (excluded_middle_informative (proj1_sig (fst u) < proj1_sig (snd u))).
 move=> H11.
 reflexivity.
 move=> H11.
@@ -5075,23 +5077,23 @@ apply sig_map.
 apply functional_extensionality.
 move=> m.
 apply sig_map.
-suff: (proj1_sig (proj1_sig u1 m) = proj1_sig (proj1_sig (exist Bijective (fun m : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig u1 (proj1_sig (blockdividesub M N m H))))%nat (H5 (proj1_sig u1 (proj1_sig (blockdividesub M N m H))))
+suff: (proj1_sig (proj1_sig u1 m) = proj1_sig (proj1_sig (exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig u1 (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig u1 (proj1_sig (blockdividesub M N m H))))
   | right _ => m
-end) (H6 u1)) (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m))) - M)%nat.
+end) (H6 u1)) (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) - M).
 move=> H10.
 rewrite H10.
 rewrite H9.
 simpl.
 elim (le_lt_dec M (M + proj1_sig m)).
 move=> H11.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)) = m)%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)) = m).
 move=> H12.
 rewrite H12.
 apply minus_plus.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) H11))) (proj1_sig m) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) H11))) (proj1_sig m) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)).
 move=> H11.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig m)).
@@ -5100,46 +5102,46 @@ apply H11.
 simpl.
 elim (le_lt_dec M (M + proj1_sig m)).
 move=> H10.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)) = m)%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)) = m).
 move=> H11.
 rewrite H11.
 simpl.
 rewrite minus_plus.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) H10))) (proj1_sig m) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) H10))) (proj1_sig m) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)).
 move=> H10.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig m)).
 apply le_plus_l.
 apply H10.
 move=> u H7.
-suff: (exists (k : {n : nat | (n < M + N)%nat}), MBlockH f M N (M + N) (MBlockW f M M N (MI f M) (MO f M N)) (MBlockW f N M N A (Mopp f N N (Mmult f N M N A B))) k (proj1_sig u k) = FO f).
+suff: (exists (k : {n : nat | (n < M + N)}), MBlockH f M N (M + N) (MBlockW f M M N (MI f M) (MO f M N)) (MBlockW f N M N A (Mopp f N N (Mmult f N M N A B))) k (proj1_sig u k) = FO f).
 elim.
 move=> k H8.
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteSingleton {n : nat | (n < M + N)%nat} k)).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteSingleton {n : nat | (n < M + N)} k)).
 rewrite MySumF2Singleton.
 rewrite H8.
 simpl.
 rewrite (Fmul_O_l f).
 apply (Fmul_O_r f).
 move=> l H9.
-apply (Full_intro {n : nat | (n < M + N)%nat} l).
+apply (Full_intro {n : nat | (n < M + N)} l).
 elim H7.
 move=> u0 H8 H9.
 apply NNPP.
 move=> H10.
 apply H8.
-suff: (forall (m : {n : nat | (n < M + N)%nat}), (proj1_sig m < M) -> (proj1_sig u0 m) = m)%nat.
+suff: (forall (m : {n : nat | (n < M + N)}), (proj1_sig m < M) -> (proj1_sig u0 m) = m).
 move=> H20.
-suff: (forall (m : {n : nat | (n < M + N)%nat}), (M <= proj1_sig m) -> (M <= proj1_sig (proj1_sig u0 m)))%nat.
+suff: (forall (m : {n : nat | (n < M + N)}), (M <= proj1_sig m) -> (M <= proj1_sig (proj1_sig u0 m))).
 move=> H11.
-suff: (exists (P : Permutation N), forall (m : {n : nat | (n < N)%nat}), proj1_sig (proj1_sig u0 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m))) = M + proj1_sig (proj1_sig P m))%nat.
+suff: (exists (P : Permutation N), forall (m : {n : nat | (n < N)}), proj1_sig (proj1_sig u0 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m))) = M + proj1_sig (proj1_sig P m)).
 elim.
 move=> P H12.
-apply (Im_intro (Permutation N) (Permutation (M + N)) (Full_set (Permutation N)) (fun (P : Permutation N) => exist Bijective (fun m : {n : nat | (n < M + N)%nat} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+apply (Im_intro (Permutation N) (Permutation (M + N)) (Full_set (Permutation N)) (fun (P : Permutation N) => exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
   | right _ => m
 end) (H6 P)) P).
 apply (Full_intro (Permutation N) P).
@@ -5150,7 +5152,7 @@ simpl.
 elim (le_lt_dec M (proj1_sig m)).
 move=> H13.
 apply sig_map.
-suff: (m = (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig (blockdividesub M N m H13)))%nat (H5 (proj1_sig (blockdividesub M N m H13))))).
+suff: (m = (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (blockdividesub M N m H13))) (H5 (proj1_sig (blockdividesub M N m H13))))).
 move=> H14.
 rewrite {1} H14.
 apply (H12 (proj1_sig (blockdividesub M N m H13))).
@@ -5160,32 +5162,32 @@ rewrite (proj2_sig (blockdividesub M N m H13)).
 reflexivity.
 move=> H13.
 apply (H20 m H13).
-suff: (forall (m : {n : nat | (n < N)%nat}), M <= M + proj1_sig m)%nat.
+suff: (forall (m : {n : nat | (n < N)}), M <= M + proj1_sig m).
 move=> H12.
-suff: (Bijective (fun (m : {n : nat | (n < N)%nat}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) (H12 m))))).
+suff: (Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (H12 m))))).
 move=> H13.
-exists (exist Bijective (fun (m : {n : nat | (n < N)%nat}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m)%nat (H5 m)) (H12 m)))) H13).
+exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (H12 m)))) H13).
 simpl.
 move=> m.
-rewrite (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m))) (H11 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) (H12 m))))%nat.
+rewrite (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m))) (H11 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) (H12 m)))).
 reflexivity.
 apply CountInjBij.
 move=> m1 m2 H13.
-suff: ((exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1)) = (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m2)%nat (H5 m2))).
+suff: ((exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m1) (H5 m1)) = (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m2) (H5 m2))).
 move=> H14.
 apply sig_map.
 apply (plus_reg_l (proj1_sig m1) (proj1_sig m2) M).
-suff: ((M + proj1_sig m1) = proj1_sig (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1)))%nat.
+suff: ((M + proj1_sig m1) = proj1_sig (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m1) (H5 m1))).
 move=> H15.
 rewrite H15.
 rewrite H14.
 reflexivity.
 reflexivity.
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
-rewrite - (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1))) (H11 (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m1)%nat (H5 m1)) (H12 m1)))).
+rewrite - (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m1) (H5 m1))) (H11 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m1) (H5 m1)) (H12 m1)))).
 rewrite H13.
-rewrite (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m2)%nat (H5 m2))) (H11 (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig m2)%nat (H5 m2)) (H12 m2)))).
+rewrite (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m2) (H5 m2))) (H11 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m2) (H5 m2)) (H12 m2)))).
 reflexivity.
 move=> m.
 apply le_plus_l.
@@ -5199,7 +5201,7 @@ suff: (m = (proj1_sig u0 m)).
 move=> H13.
 rewrite {1} H13.
 apply (le_trans (S (proj1_sig (proj1_sig u0 m))) M (proj1_sig m) H12 H11).
-apply (BijInj {n : nat | (n < M + N)%nat} {n : nat | (n < M + N)%nat} (proj1_sig u0) (proj2_sig u0)).
+apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 rewrite (H20 (proj1_sig u0 m) H12).
 reflexivity.
 move=> m H11.
@@ -5234,8 +5236,8 @@ apply (Full_intro (Permutation (M + N)) P).
 move=> P.
 elim (proj2_sig P).
 move=> Pinv H6.
-exists (fun (m : {n : nat | (n < M + N)%nat}) => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H))))%nat (H5 (Pinv (proj1_sig (blockdividesub M N m H))))
+exists (fun (m : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig m) with
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H))))
   | right _ => m
 end).
 apply conj.
@@ -5247,14 +5249,14 @@ elim (le_lt_dec M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H
 move=> H8.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8)) = (proj1_sig P (proj1_sig (blockdividesub M N m H7))))%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8)) = (proj1_sig P (proj1_sig (blockdividesub M N m H7)))).
 move=> H9.
 rewrite H9.
 rewrite (proj1 H6).
 apply (proj2_sig (blockdividesub M N m H7)).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7))))%nat (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8))) (proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8))) (proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8)).
 move=> H8.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7))))).
@@ -5275,14 +5277,14 @@ elim (le_lt_dec M (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7))))).
 move=> H8.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8)) = (Pinv (proj1_sig (blockdividesub M N m H7))))%nat.
+suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8)) = (Pinv (proj1_sig (blockdividesub M N m H7)))).
 move=> H9.
 rewrite H9.
 rewrite (proj2 H6).
 apply (proj2_sig (blockdividesub M N m H7)).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)%nat) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7))))%nat (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8))) (proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8))%nat.
+apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8))) (proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) M).
+apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8)).
 move=> H8.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7))))).
@@ -5321,7 +5323,7 @@ apply functional_extensionality.
 move=> y.
 unfold Mmult.
 unfold Mopp.
-apply (FiniteSetInduction {n : nat | (n < M)%nat} (exist (Finite (Count M)) (Full_set {n : nat | (n < M)%nat}) (CountFinite M))).
+apply (FiniteSetInduction {n : nat | (n < M)} (exist (Finite (Count M)) (Full_set {n : nat | (n < M)}) (CountFinite M))).
 apply conj.
 rewrite MySumF2Empty.
 rewrite MySumF2Empty.
@@ -5338,16 +5340,16 @@ rewrite (Fopp_mul_distr_r f).
 reflexivity.
 apply H4.
 apply H4.
-suff: (forall (k : nat) (C : Matrix f M N), cardinal ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat})) => C (fst xy) (snd xy) <> FO f) k -> Determinant f (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))) = Determinant f (M + N) (Mmult f (M + N) (M + N) (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))) (MBlockH f M N (M + N) (MBlockW f M M N (MI f M) C) (MBlockW f N M N (MO f N M) (MI f N))))).
+suff: (forall (k : nat) (C : Matrix f M N), cardinal ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : ({n : nat | (n < M)} * {n : nat | (n < N)})) => C (fst xy) (snd xy) <> FO f) k -> Determinant f (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))) = Determinant f (M + N) (Mmult f (M + N) (M + N) (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))) (MBlockH f M N (M + N) (MBlockW f M M N (MI f M) C) (MBlockW f N M N (MO f N M) (MI f N))))).
 move=> H5.
-suff: (Finite ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : {n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) => (Mopp f M N B) (fst xy) (snd xy) <> FO f)).
+suff: (Finite ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => (Mopp f M N B) (fst xy) (snd xy) <> FO f)).
 move=> H6.
-elim (finite_cardinal ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : {n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) => (Mopp f M N B) (fst xy) (snd xy) <> FO f) H6).
+elim (finite_cardinal ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => (Mopp f M N B) (fst xy) (snd xy) <> FO f) H6).
 move=> n H7.
 apply (H5 n (Mopp f M N B) H7).
-apply (Finite_downward_closed ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (Full_set ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}))).
+apply (Finite_downward_closed ({n : nat | (n < M)} * {n : nat | (n < N)}) (Full_set ({n : nat | (n < M)} * {n : nat | (n < N)}))).
 apply CountFiniteBijective.
-exists (M * N)%nat.
+exists (M * N).
 elim (CountMult M N).
 move=> g.
 elim.
@@ -5358,13 +5360,13 @@ apply conj.
 apply (proj2 H7).
 apply (proj1 H7).
 move=> xy H6.
-apply (Full_intro ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) xy).
+apply (Full_intro ({n : nat | (n < M)} * {n : nat | (n < N)}) xy).
 elim.
 move=> C H1.
 suff: ((MBlockH f M N (M + N) (MBlockW f M M N (MI f M) C) (MBlockW f N M N (MO f N M) (MI f N))) = (MI f (M + N))).
 move=> H2.
 rewrite H2.
-rewrite (Mmult_I_r f (M + N) (M + N))%nat.
+rewrite (Mmult_I_r f (M + N) (M + N)).
 reflexivity.
 apply functional_extensionality.
 move=> x.
@@ -5412,7 +5414,7 @@ reflexivity.
 move=> H2.
 elim (le_lt_dec M (proj1_sig y)).
 move=> H3.
-suff: (~ In ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : {n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) => C (fst xy) (snd xy) <> FO f) ((exist (fun n : nat => (n < M)%nat) (proj1_sig x) H2), (proj1_sig (blockdividesub M N y H3)))).
+suff: (~ In ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => C (fst xy) (snd xy) <> FO f) ((exist (fun n : nat => (n < M)) (proj1_sig x) H2), (proj1_sig (blockdividesub M N y H3)))).
 move=> H4.
 apply NNPP.
 move=> H5.
@@ -5430,41 +5432,41 @@ rewrite {2} H7.
 apply (le_trans (S (proj1_sig x)) M (proj1_sig y) H2 H3).
 move=> H7.
 reflexivity.
-rewrite (cardinal_elim ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat})) => C (fst xy) (snd xy) <> FO f) O H1).
+rewrite (cardinal_elim ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : ({n : nat | (n < M)} * {n : nat | (n < N)})) => C (fst xy) (snd xy) <> FO f) O H1).
 elim.
 move=> H3.
 reflexivity.
 move=> n H1 C H2.
-elim (cardinal_invert ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat})) => C (fst xy) (snd xy) <> FO f) (S n) H2).
+elim (cardinal_invert ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : ({n : nat | (n < M)} * {n : nat | (n < N)})) => C (fst xy) (snd xy) <> FO f) (S n) H2).
 move=> D.
 elim.
 move=> d H3.
-suff: ((MBlockH f M N (M + N) (MBlockW f M M N (MI f M) C) (MBlockW f N M N (MO f N M) (MI f N))) = Mmult f (M + N) (M + N) (M + N) (MBlockH f M N (M + N) (MBlockW f M M N (MI f M) (fun (x : {n : nat | (n < M)%nat}) (y : {n : nat | (n < N)%nat}) => match excluded_middle_informative ((x, y) = d) with
+suff: ((MBlockH f M N (M + N) (MBlockW f M M N (MI f M) C) (MBlockW f N M N (MO f N M) (MI f N))) = Mmult f (M + N) (M + N) (M + N) (MBlockH f M N (M + N) (MBlockW f M M N (MI f M) (fun (x : {n : nat | (n < M)}) (y : {n : nat | (n < N)}) => match excluded_middle_informative ((x, y) = d) with
   | left _ => FO f
   | right _ => C x y
-end)) (MBlockW f N M N (MO f N M) (MI f N))) (Mplus f (M + N) (M + N) (MI f (M + N)) (fun (x y : {n : nat | (n < M + N)%nat}) => match excluded_middle_informative (proj1_sig x = proj1_sig (fst d) /\ proj1_sig y = M + proj1_sig (snd d)) with
+end)) (MBlockW f N M N (MO f N M) (MI f N))) (Mplus f (M + N) (M + N) (MI f (M + N)) (fun (x y : {n : nat | (n < M + N)}) => match excluded_middle_informative (proj1_sig x = proj1_sig (fst d) /\ proj1_sig y = M + proj1_sig (snd d)) with
   | left _ => C (fst d) (snd d)
   | right _ => FO f
-end)))%nat.
+end))).
 move=> H4.
 rewrite H4.
 rewrite - (Mmult_assoc f).
-rewrite (H1 (fun (x : {n : nat | (n < M)%nat}) (y : {n : nat | (n < N)%nat}) => match excluded_middle_informative ((x, y) = d) with
+rewrite (H1 (fun (x : {n : nat | (n < M)}) (y : {n : nat | (n < N)}) => match excluded_middle_informative ((x, y) = d) with
   | left _ => FO f
   | right _ => C x y
 end)).
-suff: (proj1_sig (fst d) < M + N)%nat.
+suff: (proj1_sig (fst d) < M + N).
 move=> H5.
-suff: (M + proj1_sig (snd d) < M + N)%nat.
+suff: (M + proj1_sig (snd d) < M + N).
 move=> H6.
-rewrite - (DeterminantAddTransformW f (M + N) (Mmult f (M + N) (M + N) (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))) (MBlockH f M N (M + N) (MBlockW f M M N (MI f M) (fun (x : {n0 : nat | (n0 < M)%nat}) (y : {n0 : nat | (n0 < N)%nat}) => match excluded_middle_informative ((x, y) = d) with
+rewrite - (DeterminantAddTransformW f (M + N) (Mmult f (M + N) (M + N) (M + N) (MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N))) (MBlockH f M N (M + N) (MBlockW f M M N (MI f M) (fun (x : {n0 : nat | (n0 < M)}) (y : {n0 : nat | (n0 < N)}) => match excluded_middle_informative ((x, y) = d) with
   | left _ => FO f
   | right _ => C x y
-end)) (MBlockW f N M N (MO f N M) (MI f N)))) (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H5) (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (snd d)) H6) (C (fst d) (snd d)))%nat.
-suff: (forall (X : Matrix f (M + N) (M + N)), (fun (x y : {n : nat | (n < M + N)%nat}) => match Nat.eq_dec (proj1_sig y) (proj1_sig (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (snd d))%nat H6)) with
-  | left _ => Fadd f (X x y) (Fmul f (C (fst d) (snd d)) (X x (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H5)))
+end)) (MBlockW f N M N (MO f N M) (MI f N)))) (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H5) (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (snd d)) H6) (C (fst d) (snd d))).
+suff: (forall (X : Matrix f (M + N) (M + N)), (fun (x y : {n : nat | (n < M + N)}) => match Nat.eq_dec (proj1_sig y) (proj1_sig (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (snd d)) H6)) with
+  | left _ => Fadd f (X x y) (Fmul f (C (fst d) (snd d)) (X x (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H5)))
   | right _ => X x y
-end) = (Mmult f (M + N) (M + N) (M + N) X (Mplus f (M + N) (M + N) (MI f (M + N)) (fun (x y : {n : nat | (n < M + N)%nat}) => match excluded_middle_informative (proj1_sig x = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))%nat) with
+end) = (Mmult f (M + N) (M + N) (M + N) X (Mplus f (M + N) (M + N) (MI f (M + N)) (fun (x y : {n : nat | (n < M + N)}) => match excluded_middle_informative (proj1_sig x = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))) with
   | left _ => C (fst d) (snd d)
   | right _ => FO f
 end)))).
@@ -5479,15 +5481,15 @@ move=> y.
 rewrite (Mmult_plus_distr_l f).
 rewrite (Mmult_I_r f).
 unfold Mmult.
-elim (Nat.eq_dec (proj1_sig y) (proj1_sig (exist (fun (n : nat) => (n < M + N)%nat) (M + proj1_sig (snd d))%nat H6))).
+elim (Nat.eq_dec (proj1_sig y) (proj1_sig (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (snd d)) H6))).
 simpl.
 move=> H7.
 unfold Mplus.
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteSingleton {n : nat | (n < M + N)%nat} (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H5))).
-rewrite (MySumF2O {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)%nat} (proj1_sig (FiniteSingleton {n : nat | (n < M + N)%nat} (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H5)))))).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteSingleton {n : nat | (n < M + N)} (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H5))).
+rewrite (MySumF2O {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)} (proj1_sig (FiniteSingleton {n : nat | (n < M + N)} (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H5)))))).
 rewrite MySumF2Singleton.
 rewrite (CM_O_r (FPCM f)).
-elim (excluded_middle_informative (proj1_sig (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H5) = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))%nat)).
+elim (excluded_middle_informative (proj1_sig (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H5) = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d)))).
 move=> H8.
 rewrite (Fmul_comm f).
 reflexivity.
@@ -5500,11 +5502,11 @@ apply H7.
 move=> u.
 elim.
 move=> u0 H8 H9.
-elim (excluded_middle_informative (proj1_sig u0 = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))%nat)).
+elim (excluded_middle_informative (proj1_sig u0 = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d)))).
 move=> H10.
 apply False_ind.
 apply H8.
-suff: (u0 = (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H5)).
+suff: (u0 = (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H5)).
 move=> H11.
 rewrite H11.
 apply In_singleton.
@@ -5513,7 +5515,7 @@ apply (proj1 H10).
 move=> H10.
 apply (Fmul_O_r f).
 move=> k H8.
-apply (Full_intro {n : nat | (n < M + N)%nat} k).
+apply (Full_intro {n : nat | (n < M + N)} k).
 simpl.
 move=> H7.
 unfold Mplus.
@@ -5521,7 +5523,7 @@ rewrite MySumF2O.
 rewrite (Fadd_O_r f).
 reflexivity.
 move=> u H8.
-elim (excluded_middle_informative (proj1_sig u = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))%nat)).
+elim (excluded_middle_informative (proj1_sig u = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d)))).
 move=> H9.
 apply False_ind.
 apply H7.
@@ -5537,7 +5539,7 @@ apply le_plus_l.
 apply (plus_lt_compat_l (proj1_sig (snd d)) N M (proj2_sig (snd d))).
 apply (le_trans (S (proj1_sig (fst d))) M (M + N) (proj2_sig (fst d))).
 apply le_plus_l.
-suff: ((fun (xy : {n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) => (match excluded_middle_informative ((fst xy, snd xy) = d) with
+suff: ((fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => (match excluded_middle_informative ((fst xy, snd xy) = d) with
   | left _ => FO f
   | right _ => C (fst xy) (snd xy)
 end) <> FO f) = D).
@@ -5554,7 +5556,7 @@ apply False_ind.
 apply H6.
 reflexivity.
 move=> H5 H6.
-suff: (In ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : {n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) => C (fst xy) (snd xy) <> FO f) xy).
+suff: (In ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => C (fst xy) (snd xy) <> FO f) xy).
 rewrite (proj1 H3).
 move=> H7.
 suff: ((fst xy, snd xy) <> d).
@@ -5585,7 +5587,7 @@ apply injective_projections.
 reflexivity.
 reflexivity.
 move=> H6.
-suff: (In ({n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) (fun (xy : {n : nat | (n < M)%nat} * {n : nat | (n < N)%nat}) => C (fst xy) (snd xy) <> FO f) xy).
+suff: (In ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => C (fst xy) (snd xy) <> FO f) xy).
 apply.
 rewrite (proj1 H3).
 left.
@@ -5598,14 +5600,14 @@ apply functional_extensionality.
 move=> x.
 apply functional_extensionality.
 move=> y.
-suff: (proj1_sig (fst d) < M + N)%nat.
+suff: (proj1_sig (fst d) < M + N).
 move=> H4.
-rewrite (MySumF2Included {n : nat | (n < M + N)%nat} (FiniteSingleton {n : nat | (n < M + N)%nat} (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H4))).
-rewrite (MySumF2O {n : nat | (n < M + N)%nat} (FiniteIntersection {n : nat | (n < M + N)%nat} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)%nat}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)%nat} (proj1_sig (FiniteSingleton {n : nat | (n < M + N)%nat} (exist (fun (n : nat) => (n < M + N)%nat) (proj1_sig (fst d)) H4)))))).
+rewrite (MySumF2Included {n : nat | (n < M + N)} (FiniteSingleton {n : nat | (n < M + N)} (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H4))).
+rewrite (MySumF2O {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (Complement {n : nat | (n < M + N)} (proj1_sig (FiniteSingleton {n : nat | (n < M + N)} (exist (fun (n : nat) => (n < M + N)) (proj1_sig (fst d)) H4)))))).
 rewrite (CM_O_r (FPCM f)).
 rewrite MySumF2Singleton.
 simpl.
-elim (excluded_middle_informative (proj1_sig (fst d) = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))%nat)).
+elim (excluded_middle_informative (proj1_sig (fst d) = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d)))).
 move=> H5.
 unfold MBlockH.
 unfold MBlockW.
@@ -5638,11 +5640,11 @@ move=> H8.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (fst d)) H8 (proj2_sig (fst d))).
 move=> H8.
-elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)%nat) (proj1_sig x) H6, proj1_sig (blockdividesub M N y H7)) = d)).
+elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)) (proj1_sig x) H6, proj1_sig (blockdividesub M N y H7)) = d)).
 move=> H9.
 rewrite (Fadd_O_l f).
 unfold MI.
-elim (Nat.eq_dec (proj1_sig (exist (fun n0 : nat => (n0 < M)%nat) (proj1_sig x) H6)) (proj1_sig (exist (fun n0 : nat => (n0 < M)%nat) (proj1_sig (fst d)) H8))).
+elim (Nat.eq_dec (proj1_sig (exist (fun n0 : nat => (n0 < M)) (proj1_sig x) H6)) (proj1_sig (exist (fun n0 : nat => (n0 < M)) (proj1_sig (fst d)) H8))).
 move=> H10.
 rewrite (Fmul_I_l f).
 rewrite - H9.
@@ -5655,7 +5657,7 @@ rewrite - H9.
 reflexivity.
 move=> H9.
 unfold MI.
-elim (Nat.eq_dec (proj1_sig (exist (fun n0 : nat => (n0 < M)%nat) (proj1_sig x) H6)) (proj1_sig (exist (fun n0 : nat => (n0 < M)%nat) (proj1_sig (fst d)) H8))).
+elim (Nat.eq_dec (proj1_sig (exist (fun n0 : nat => (n0 < M)) (proj1_sig x) H6)) (proj1_sig (exist (fun n0 : nat => (n0 < M)) (proj1_sig (fst d)) H8))).
 move=> H10.
 apply False_ind.
 apply H9.
@@ -5689,7 +5691,7 @@ reflexivity.
 move=> H6.
 elim (le_lt_dec M (proj1_sig y)).
 move=> H7.
-elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)%nat) (proj1_sig x) H6, proj1_sig (blockdividesub M N y H7)) = d)).
+elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)) (proj1_sig x) H6, proj1_sig (blockdividesub M N y H7)) = d)).
 move=> H8.
 apply False_ind.
 apply H5.
@@ -5706,11 +5708,11 @@ reflexivity.
 move=> u.
 elim.
 move=> u0 H5 H6.
-elim (excluded_middle_informative (proj1_sig u0 = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d))%nat)).
+elim (excluded_middle_informative (proj1_sig u0 = proj1_sig (fst d) /\ proj1_sig y = (M + proj1_sig (snd d)))).
 move=> H7.
 apply False_ind.
 apply H5.
-suff: ((exist (fun n0 : nat => (n0 < M + N)%nat) (proj1_sig (fst d)) H4) = u0).
+suff: ((exist (fun n0 : nat => (n0 < M + N)) (proj1_sig (fst d)) H4) = u0).
 move=> H8.
 rewrite H8.
 apply In_singleton.
@@ -5720,7 +5722,7 @@ reflexivity.
 move=> H7.
 apply (Fmul_O_r f).
 move=> k H5.
-apply (Full_intro {n : nat | (n < M + N)%nat} k).
+apply (Full_intro {n : nat | (n < M + N)} k).
 apply (le_trans (S (proj1_sig (fst d))) M (M + N) (proj2_sig (fst d)) (le_plus_l M N)).
 Qed.
 
@@ -5728,7 +5730,7 @@ Lemma DeterminantMult : forall (f : Field) (N : nat) (A B : Matrix f N N), Deter
 Proof.
 move=> f N A B.
 rewrite (CauchyBinet f N N A B).
-suff: ((FiniteIntersection ({n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat}) (exist (Finite ({n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat})) (Full_set ({n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat})) (CountPowFinite N N)) (fun r : {n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat} => forall p q : {n : nat | (n < N)%nat}, (proj1_sig p < proj1_sig q)%nat -> (proj1_sig (r p) < proj1_sig (r q))%nat)) = FiniteSingleton ({n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat}) (fun (m : {n : nat | (n < N)%nat}) => m)).
+suff: ((FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < N)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < N)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < N)})) (CountPowFinite N N)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < N)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) = FiniteSingleton ({n : nat | (n < N)} -> {n : nat | (n < N)}) (fun (m : {n : nat | (n < N)}) => m)).
 move=> H1.
 rewrite H1.
 rewrite MySumF2Singleton.
@@ -5739,14 +5741,14 @@ apply conj.
 move=> g.
 elim.
 move=> G H1 H2.
-suff: (G = (fun (m : {n : nat | (n < N)%nat}) => m)).
+suff: (G = (fun (m : {n : nat | (n < N)}) => m)).
 move=> H3.
 rewrite H3.
 apply In_singleton.
 apply functional_extensionality.
-suff: (forall (k : nat), k <= N -> forall (m : {n : nat | (n < N)%nat}), proj1_sig m < k -> proj1_sig m <= proj1_sig (G m))%nat.
+suff: (forall (k : nat), k <= N -> forall (m : {n : nat | (n < N)}), proj1_sig m < k -> proj1_sig m <= proj1_sig (G m)).
 move=> H3.
-suff: (forall (k : nat), k <= N -> forall (m : {n : nat | (n < N)%nat}), proj1_sig m + k >= N -> proj1_sig m >= proj1_sig (G m))%nat.
+suff: (forall (k : nat), k <= N -> forall (m : {n : nat | (n < N)}), proj1_sig m + k >= N -> proj1_sig m >= proj1_sig (G m)).
 move=> H4 m.
 apply sig_map.
 apply (le_antisym (proj1_sig (G m)) (proj1_sig m)).
@@ -5764,12 +5766,12 @@ move=> k H4 H5 m H6.
 elim (le_lt_or_eq (S (proj1_sig m)) N).
 move=> H7.
 apply (le_S_n (proj1_sig (G m)) (proj1_sig m)).
-apply (le_trans (S (proj1_sig (G m))) (proj1_sig (G (exist (fun (n : nat) => n < N) (S (proj1_sig m)) H7))) (S (proj1_sig m)))%nat.
-apply (H1 m (exist (fun (n : nat) => n < N) (S (proj1_sig m)) H7))%nat.
+apply (le_trans (S (proj1_sig (G m))) (proj1_sig (G (exist (fun (n : nat) => n < N) (S (proj1_sig m)) H7))) (S (proj1_sig m))).
+apply (H1 m (exist (fun (n : nat) => n < N) (S (proj1_sig m)) H7)).
 apply (le_n (S (proj1_sig m))).
-apply (H4 (le_trans k (S k) N (le_S k k (le_n k)) H5) (exist (fun (n : nat) => n < N) (S (proj1_sig m)) H7))%nat.
+apply (H4 (le_trans k (S k) N (le_S k k (le_n k)) H5) (exist (fun (n : nat) => n < N) (S (proj1_sig m)) H7)).
 simpl.
-suff: (S (proj1_sig m + k) = proj1_sig m + S k)%nat.
+suff: (S (proj1_sig m + k) = proj1_sig m + S k).
 move=> H8.
 rewrite H8.
 apply H6.
@@ -5789,16 +5791,16 @@ move=> H6.
 suff: (exists (k : nat), S k = proj1_sig m).
 elim.
 move=> k H7.
-suff: (k < N)%nat.
+suff: (k < N).
 move=> H8.
-apply (le_trans (proj1_sig m) (S (proj1_sig (G (exist (fun (l : nat) => l < N) k H8)))) (proj1_sig (G m)))%nat.
+apply (le_trans (proj1_sig m) (S (proj1_sig (G (exist (fun (l : nat) => l < N) k H8)))) (proj1_sig (G m))).
 rewrite - H7.
 apply le_n_S.
-apply (H3 (le_trans n (S n) N (le_S n n (le_n n)) H4) (exist (fun (l : nat) => l < N) k H8))%nat.
+apply (H3 (le_trans n (S n) N (le_S n n (le_n n)) H4) (exist (fun (l : nat) => l < N) k H8)).
 apply (lt_S_n k n).
 rewrite H7.
 apply H5.
-apply (H1 (exist (fun (l : nat) => l < N) k H8) m)%nat.
+apply (H1 (exist (fun (l : nat) => l < N) k H8) m).
 rewrite - H7.
 apply (le_n (S k)).
 unfold lt.
@@ -5806,7 +5808,7 @@ rewrite H7.
 apply (le_trans (proj1_sig m) (S n) N).
 apply (lt_le_weak (proj1_sig m) (S n) H5).
 apply H4.
-suff: (0 < proj1_sig m)%nat.
+suff: (0 < proj1_sig m).
 elim (proj1_sig m).
 move=> H7.
 apply False_ind.
@@ -5824,7 +5826,7 @@ apply Intersection_intro.
 elim H1.
 move=> p q.
 apply.
-apply (Full_intro ({n : nat | (n < N)%nat} -> {n : nat | (n < N)%nat}) g).
+apply (Full_intro ({n : nat | (n < N)} -> {n : nat | (n < N)}) g).
 Qed.
 
 End Matrix.


### PR DESCRIPTION
## 背景
有理数ライブラリを入れているせいで自然数の演算が有理数の演算だと解釈されて邪魔なので消したい。
## 概要
行列ライブラリから有理数ライブラリを消す。自然数の演算を自然数の演算だと明示する必要がなくなったのでそれを消す。
