### PR TITLE
行列のブロック分けをリファクタリング

### DIFF
--- a/LinearAlgebra/Matrix.v
+++ b/LinearAlgebra/Matrix.v
@@ -1729,14 +1729,14 @@ Qed.
 Lemma CauchyBinet : forall (f : Field) (N M : nat) (A : Matrix f N M) (B : Matrix f M N), Determinant f N (Mmult f N M N A B) = MySumF2 ({n : nat | (n < N)} -> {n : nat | (n < M)}) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun (r : ({n : nat | (n < N)} -> {n : nat | (n < M)})) => forall (p q : {n : nat | (n < N)}), (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FPCM f) (fun (r : ({n : nat | (n < N)} -> {n : nat | (n < M)})) => Fmul f (Determinant f N (fun (x y : {n : nat | (n < N)}) => A x (r y))) (Determinant f N (fun (x y : {n : nat | (n < N)}) => B (r x) y))).
 Proof.
 suff: (forall (m1 m2 : nat) (x : {n : nat | (n < m1 + m2)}), (m1 <= proj1_sig x) -> {y : {n : nat | (n < m2)} | (m1 + proj1_sig y = proj1_sig x)}).
-move=> blockdividesub f N M A B.
+move=> H37 f N M A B.
 suff: (MBlockH = fun (f : Field) (M1 M2 N : nat) (A1 : Matrix f M1 N) (A2 : Matrix f M2 N) (x : {n : nat | (n < M1 + M2)}) (y : {n : nat | (n < N)}) => match (le_lt_dec M1 (proj1_sig x)) with
-  | left a => A2 (proj1_sig (blockdividesub M1 M2 x a)) y
+  | left a => A2 (proj1_sig (H37 M1 M2 x a)) y
   | right b => A1 (exist (fun (n : nat) => (n < M1)) (proj1_sig x) b) y
 end).
 move=> H35.
 suff: (MBlockW = fun (f : Field) (M N1 N2 : nat) (A1 : Matrix f M N1) (A2 : Matrix f M N2) (x : {n : nat | (n < M)}) (y : {n : nat | (n < N1 + N2)}) => match (le_lt_dec N1 (proj1_sig y)) with
-  | left a => A2 x (proj1_sig (blockdividesub N1 N2 y a))
+  | left a => A2 x (proj1_sig (H37 N1 N2 y a))
   | right b => A1 x (exist (fun (n : nat) => (n < N1)) (proj1_sig y) b)
 end).
 move=> H36.
@@ -1754,7 +1754,7 @@ suff: (forall (l : {n : nat | (n < N)}), (M + proj1_sig l < M + N)).
 move=> H5.
 suff: (forall (x : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N)))), Bijective ((fun (x : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N)))) => match excluded_middle_informative (Injective (fst x)) with
   | left a => (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun (s : nat) => (s < M)) (proj1_sig k) b = fst x l) with
       | left c => exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
@@ -1765,7 +1765,7 @@ end) x)).
 move=> H6.
 rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N))) (Permutation (M + N)) (fun (x : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * ((Permutation N) * (Permutation N)))) => exist Bijective (match excluded_middle_informative (Injective (fst x)) with
   | left a => (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun (s : nat) => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun (s : nat) => (s < M)) (proj1_sig k) b = fst x l) with
       | left c => exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
@@ -1775,7 +1775,7 @@ rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (({n : nat | (n < N)} -
 end) (H6 x)) (FinitePair ({n : nat | (n < N)} -> {n : nat | (n < M)}) ((Permutation N) * (Permutation N)) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N)))).
 rewrite (MySumF2O (Permutation (M + N)) (FiniteIntersection (Permutation (M + N)) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N))) (Complement (Permutation (M + N)) (proj1_sig (FiniteIm (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) (Permutation (M + N)) (fun x : ({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N) => exist Bijective match excluded_middle_informative (Injective (fst x)) with
   | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst x l) with
       | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
@@ -1787,7 +1787,7 @@ rewrite - (MySumF2BijectiveSame2 (({n : nat | (n < N)} -> {n : nat | (n < M)}) *
 unfold Basics.compose.
 rewrite (MySumF2Pair ({n : nat | (n < N)} -> {n : nat | (n < M)}) ((Permutation N) * (Permutation N)) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (FPCM f) (fun (x : ({n : nat | (n < N)} -> {n : nat | (n < M)})) (y : (Permutation N * Permutation N)) => Fmul f match PermutationParity (M + N) (exist Bijective match excluded_middle_informative (Injective x) with
     | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-      | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k b)))))
+      | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (H37 M N k b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (H37 M N k b)))))
       | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = x l) with
         | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
         | right _ => k
@@ -1799,7 +1799,7 @@ rewrite (MySumF2Pair ({n : nat | (n < N)} -> {n : nat | (n < M)}) ((Permutation 
   | OFF => FI f
 end (MySumF2 {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (FMCM f) (fun k : {n : nat | (n < M + N)} => MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig (exist Bijective match excluded_middle_informative (Injective x) with
   | left a => fun k0 : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k0) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k0 b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (blockdividesub M N k0 b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (x (proj1_sig (fst y) (proj1_sig (H37 M N k0 b))))) (H4 (x (proj1_sig (fst y) (proj1_sig (H37 M N k0 b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k0) b = x l) with
       | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => s < M) (proj1_sig k0) b) a c)))) (H5 (proj1_sig (snd y) (proj1_sig (H3 x (exist (fun s : nat => (s < M)) (proj1_sig k0) b) a c))))
       | right _ => k0
@@ -1870,7 +1870,7 @@ end)).
 rewrite - (Fmul_assoc f (PowF f (Fopp f (FI f)) N)).
 suff: ((Fmul f (PowF f (Fopp f (FI f)) N) match PermutationParity (M + N) (exist Bijective match excluded_middle_informative (Injective c) with
     | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-      | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b)))))
+      | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (H37 M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (H37 M N k b)))))
       | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
         | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) a c0)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c0))))
         | right _ => k
@@ -1896,7 +1896,7 @@ rewrite (MySumF2O {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M 
 rewrite (CM_O_r (FMCM f)).
 suff: ((MySumF2 {n : nat | (n < M + N)} (FiniteIntersection {n : nat | (n < M + N)} (exist (Finite (Count (M + N))) (Full_set {n : nat | (n < M + N)}) (CountFinite (M + N))) (fun k : {n : nat | (n < M + N)} => (M <= proj1_sig k))) (FMCM f) (fun k : {n : nat | (n < M + N)} => MBlockW f (M + N) M N (MBlockH f M N M (MI f M) A) (MBlockH f M N N B (MO f N N)) k (proj1_sig (exist Bijective match excluded_middle_informative (Injective c) with
   | left a => fun k0 : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k0) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k0 b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k0 b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (H37 M N k0 b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (H37 M N k0 b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k0) b = c l) with
       | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k0) b) a c0)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k0) b) a c0))))
       | right _ => k0
@@ -1938,13 +1938,13 @@ move=> H24.
 suff: ((exist (fun n : nat => (n < M)) (proj1_sig (c u)) H24) = c u).
 move=> H25.
 rewrite H25.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23)) = (proj1_sig (snd d) u)).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23)) = (proj1_sig (snd d) u)).
 move=> H26.
 rewrite H26.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23))) (proj1_sig (proj1_sig (snd d) u)) M).
-rewrite ((proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23))).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23))) (proj1_sig (proj1_sig (snd d) u)) M).
+rewrite ((proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c u)) H21) H20 H22)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22))))) H23))).
 simpl.
 suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c u)) H21) H20 H22)) = u).
 move=> H26.
@@ -2038,14 +2038,14 @@ simpl.
 elim (le_lt_dec M (M + proj1_sig u)).
 move=> H20.
 simpl.
-elim (le_lt_dec M (@proj1_sig nat (fun n : nat => lt n M) (c (@proj1_sig (forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N)) (fun f0 : forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N) => @Bijective (@sig nat (fun n : nat => lt n N)) (@sig nat (fun n : nat => lt n N)) f0) (@fst (Permutation N) (Permutation N) d) (@proj1_sig (@sig nat (fun n : nat => lt n N)) (fun y : @sig nat (fun n : nat => lt n N) => @eq nat (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) y)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) u))) (blockdividesub M N (@exist nat (fun l : nat => lt l (Init.Nat.add M N)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) u)) (H5 u)) H20)))))).
+elim (le_lt_dec M (@proj1_sig nat (fun n : nat => lt n M) (c (@proj1_sig (forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N)) (fun f0 : forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N) => @Bijective (@sig nat (fun n : nat => lt n N)) (@sig nat (fun n : nat => lt n N)) f0) (@fst (Permutation N) (Permutation N) d) (@proj1_sig (@sig nat (fun n : nat => lt n N)) (fun y : @sig nat (fun n : nat => lt n N) => @eq nat (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) y)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) u))) (H37 M N (@exist nat (fun l : nat => lt l (Init.Nat.add M N)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) u)) (H5 u)) H20)))))).
 move=> H21.
 apply False_ind.
-apply (lt_not_le (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) M (proj2_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) H21).
+apply (lt_not_le (proj1_sig (c (proj1_sig (fst d) (proj1_sig (H37 M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) M (proj2_sig (c (proj1_sig (fst d) (proj1_sig (H37 M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) H21).
 move=> H21.
-suff: ((proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20)) = u).
+suff: ((proj1_sig (H37 M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20)) = u).
 move=> H22.
-suff: ((exist (fun n : nat => (n < M)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) H21) = (c (proj1_sig (fst d) u))).
+suff: ((exist (fun n : nat => (n < M)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (H37 M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))))) H21) = (c (proj1_sig (fst d) u))).
 move=> H23.
 rewrite H23.
 rewrite H22.
@@ -2055,8 +2055,8 @@ simpl.
 rewrite H22.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))) (proj1_sig u) M).
-apply (proj2_sig (blockdividesub M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20))) (proj1_sig u) M).
+apply (proj2_sig (H37 M N (exist (fun l : nat => (l < M + N)) (M + proj1_sig u) (H5 u)) H20)).
 move=> H20.
 apply False_ind.
 apply (lt_not_le (M + proj1_sig u) M H20).
@@ -2221,7 +2221,7 @@ move=> H19.
 suff: (Injective c).
 move=> H20.
 suff: (Bijective (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (H37 M N k b)))) (H4 (c (proj1_sig (H37 M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
@@ -2234,7 +2234,7 @@ suff: (Injective (fun (k : {n : nat | (n < N)}) => exist (fun (n : nat) => (n < 
 move=> H23.
 suff: ((exist Bijective match excluded_middle_informative (Injective c) with
   | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (fst d) (proj1_sig (H37 M N k b))))) (H4 (c (proj1_sig (fst d) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
       | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) a c0)))) (H5 (proj1_sig (snd d) (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c0))))
       | right _ => k
@@ -2242,7 +2242,7 @@ suff: ((exist Bijective match excluded_middle_informative (Injective c) with
   end
   | right _ => fun k : {n0 : nat | (n0 < M + N)} => k
 end (H6 (c, d))) = PermutationCompose (M + N) (exist Bijective (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (H37 M N k b)))) (H4 (c (proj1_sig (H37 M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
@@ -2287,27 +2287,27 @@ simpl.
 elim (le_lt_dec M (proj1_sig k)).
 move=> H26.
 simpl.
-elim (le_lt_dec M (proj1_sig (c (proj1_sig (blockdividesub M N k H26))))).
+elim (le_lt_dec M (proj1_sig (c (proj1_sig (H37 M N k H26))))).
 move=> H27.
 apply False_ind.
-apply (le_not_lt M (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27 (proj2_sig (c (proj1_sig (blockdividesub M N k H26))))).
+apply (le_not_lt M (proj1_sig (c (proj1_sig (H37 M N k H26)))) H27 (proj2_sig (c (proj1_sig (H37 M N k H26))))).
 move=> H27.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (H37 M N k H26)))) H27 = c l)).
 move=> H28.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27) H20 H28)) = (proj1_sig (blockdividesub M N k H26))).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (H37 M N k H26)))) H27) H20 H28)) = (proj1_sig (H37 M N k H26))).
 move=> H29.
 rewrite H29.
-apply (proj2_sig (blockdividesub M N k H26)).
+apply (proj2_sig (H37 M N k H26)).
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H26)))) H27) H20 H28)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (H37 M N k H26)))) H27) H20 H28)).
 apply sig_map.
 reflexivity.
 move=> H28.
 apply False_ind.
 apply H28.
-exists (proj1_sig (blockdividesub M N k H26)).
+exists (proj1_sig (H37 M N k H26)).
 apply sig_map.
 reflexivity.
 move=> H26.
@@ -2323,13 +2323,13 @@ move=> l H29.
 suff: (proj1_sig k = proj1_sig (c l)).
 move=> H30.
 rewrite {7} H30.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28)) = l).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28)) = l).
 move=> H31.
 rewrite H31.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28))) (proj1_sig l) M).
-rewrite ((proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28))).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28))) (proj1_sig l) M).
+rewrite ((proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H26) H20 H27))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)))) H28))).
 simpl.
 suff: ((proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H26) H20 H27)) = l).
 move=> H31.
@@ -2368,7 +2368,7 @@ move=> H29.
 reflexivity.
 simpl.
 suff: ((fun (k : {n : nat | (n < M + N)}) => (proj1_sig match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => s < M + N) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | left b => exist (fun s : nat => s < M + N) (proj1_sig (c (proj1_sig (H37 M N k b)))) (H4 (c (proj1_sig (H37 M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | n < N}, exist (fun s : nat => s < M) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => s < M + N) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0)))
     | right _ => k
@@ -2379,18 +2379,18 @@ rewrite H26.
 apply (CardinalSigSame {n : nat | (n < M + N)}).
 apply (CountCardinalBijective {t : {n : nat | (n < M + N)} | (M <= proj1_sig t)}).
 exists (fun (k : {n : nat | (n < N)}) => (exist (fun (t : {n : nat | (n < M + N)}) => (M <= proj1_sig t)) (exist (fun (l : nat) => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))).
-exists (fun (k : {t : {n : nat | (n < M + N)} | (M <= proj1_sig t)}) => proj1_sig (blockdividesub M N (proj1_sig k) (proj2_sig k))).
+exists (fun (k : {t : {n : nat | (n < M + N)} | (M <= proj1_sig t)}) => proj1_sig (H37 M N (proj1_sig k) (proj2_sig k))).
 apply conj.
 move=> k.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k))))))) (proj1_sig k) M).
-rewrite (proj2_sig (blockdividesub M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))))).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k))))))) (proj1_sig k) M).
+rewrite (proj2_sig (H37 M N (proj1_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))) (proj2_sig (exist (fun t : {n : nat | (n < M + N)} => (M <= proj1_sig t)) (exist (fun l : nat => (l < M + N)) (M + proj1_sig k) (H5 k)) (le_plus_l M (proj1_sig k)))))).
 reflexivity.
 move=> y.
 apply sig_map.
 apply sig_map.
 simpl.
-apply (proj2_sig (blockdividesub M N (proj1_sig y) (proj2_sig y))).
+apply (proj2_sig (H37 M N (proj1_sig y) (proj2_sig y))).
 apply Extensionality_Ensembles.
 apply conj.
 move=> k.
@@ -2417,7 +2417,7 @@ move=> k H26.
 unfold In.
 elim (le_lt_dec M (proj1_sig k)).
 move=> H27.
-apply (le_trans (S (proj1_sig (c (proj1_sig (blockdividesub M N k H27))))) M (proj1_sig k) (proj2_sig (c (proj1_sig (blockdividesub M N k H27)))) H27).
+apply (le_trans (S (proj1_sig (c (proj1_sig (H37 M N k H27))))) M (proj1_sig k) (proj2_sig (c (proj1_sig (H37 M N k H27)))) H27).
 move=> H27.
 apply False_ind.
 apply (le_not_lt M (proj1_sig k) H26 H27).
@@ -2460,21 +2460,21 @@ elim (le_lt_dec M (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (f
 move=> H28.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (fst d) (proj1_sig (blockdividesub M N k H25))) = (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28))).
+suff: ((proj1_sig (fst d) (proj1_sig (H37 M N k H25))) = (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28))).
 move=> H29.
 rewrite H29.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (fst d) (proj1_sig (blockdividesub M N k H25)))) (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28))) M).
-rewrite (proj2_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28)).
+apply (plus_reg_l (proj1_sig (proj1_sig (fst d) (proj1_sig (H37 M N k H25)))) (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28))) M).
+rewrite (proj2_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | n < N} => exist (fun n : nat => n < M + N) (M + proj1_sig k0) (H5 k0)) k H22 H27)))) (H5 (proj1_sig (fst d) (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))))) H28)).
 simpl.
-suff: ((proj1_sig (blockdividesub M N k H25)) = (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))).
+suff: ((proj1_sig (H37 M N k H25)) = (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))).
 move=> H29.
 rewrite H29.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N k H25))) (proj1_sig (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))) M).
-rewrite (proj2_sig (blockdividesub M N k H25)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N k H25))) (proj1_sig (proj1_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27))) M).
+rewrite (proj2_sig (H37 M N k H25)).
 rewrite {1} (proj2_sig (H16 N (M + N) (fun k0 : {n : nat | (n < N)} => exist (fun n : nat => (n < M + N)) (M + proj1_sig k0) (H5 k0)) k H22 H27)).
 reflexivity.
 move=> H28.
@@ -2623,20 +2623,20 @@ rewrite H22.
 reflexivity.
 reflexivity.
 exists (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (H37 M N k b)))) (H4 (c (proj1_sig (H37 M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
 end).
 suff: (forall (x : {n : nat | (n < M + N)}), Basics.compose (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (H37 M N k b)))) (H4 (c (proj1_sig (H37 M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
   end
 end) (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (blockdividesub M N k b)))) (H4 (c (proj1_sig (blockdividesub M N k b))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (c (proj1_sig (H37 M N k b)))) (H4 (c (proj1_sig (H37 M N k b))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = c l) with
     | left c0 => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) b) H20 c0))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) b) H20 c0)))
     | right _ => k
@@ -2651,27 +2651,27 @@ unfold Basics.compose.
 elim (le_lt_dec M (proj1_sig k)).
 move=> H21.
 simpl.
-elim (le_lt_dec M (proj1_sig (c (proj1_sig (blockdividesub M N k H21))))).
+elim (le_lt_dec M (proj1_sig (c (proj1_sig (H37 M N k H21))))).
 move=> H22.
 apply False_ind.
-apply (le_not_lt M (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22 (proj2_sig (c (proj1_sig (blockdividesub M N k H21))))).
+apply (le_not_lt M (proj1_sig (c (proj1_sig (H37 M N k H21)))) H22 (proj2_sig (c (proj1_sig (H37 M N k H21))))).
 move=> H22.
-elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22 = c l)).
+elim (excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (H37 M N k H21)))) H22 = c l)).
 move=> H23.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22) H20 H23)) = (proj1_sig (blockdividesub M N k H21))).
+suff: ((proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig (c (proj1_sig (H37 M N k H21)))) H22) H20 H23)) = (proj1_sig (H37 M N k H21))).
 move=> H24.
 rewrite H24.
-apply (proj2_sig (blockdividesub M N k H21)).
+apply (proj2_sig (H37 M N k H21)).
 apply H20.
-rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (blockdividesub M N k H21)))) H22) H20 H23)).
+rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig (c (proj1_sig (H37 M N k H21)))) H22) H20 H23)).
 apply sig_map.
 reflexivity.
 move=> H23.
 apply False_ind.
 apply H23.
-exists (proj1_sig (blockdividesub M N k H21)).
+exists (proj1_sig (H37 M N k H21)).
 apply sig_map.
 reflexivity.
 move=> H21.
@@ -2682,14 +2682,14 @@ elim (le_lt_dec M (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)
 move=> H23.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23)) = (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23)) = (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))).
 move=> H24.
 rewrite H24.
 rewrite - (proj2_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)).
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23))) (proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23))) (proj1_sig (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22))) M).
+apply (proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H3 c (exist (fun s : nat => s < M) (proj1_sig k) H21) H20 H22))) (H5 (proj1_sig (H3 c (exist (fun s : nat => (s < M)) (proj1_sig k) H21) H20 H22)))) H23)).
 move=> H23.
 apply False_ind.
 apply (lt_irrefl M).
@@ -3270,7 +3270,7 @@ suff: (forall (u : (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation 
 move=> H7 u1 u2 H8 H9 H10.
 suff: (proj1_sig (exist Bijective match excluded_middle_informative (Injective (fst u1)) with
   | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
       | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
@@ -3279,7 +3279,7 @@ suff: (proj1_sig (exist Bijective match excluded_middle_informative (Injective (
   | right _ => fun k : {n : nat | (n < M + N)} => k
 end (H6 u1)) = proj1_sig (exist Bijective match excluded_middle_informative (Injective (fst u2)) with
   | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (H37 M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u2 l) with
       | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
@@ -3304,7 +3304,7 @@ apply H11.
 rewrite {2} H14.
 apply sig_map.
 suff: (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) k)) = let temp := (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b)))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
     | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
@@ -3317,13 +3317,13 @@ simpl.
 elim (le_lt_dec M (M + proj1_sig k)).
 move=> H16.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16)) = k).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16)) = k).
 move=> H17.
 rewrite H17.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16))) (proj1_sig k) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16))) (proj1_sig k) M).
+apply (proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H16)).
 move=> H16.
 apply False_ind.
 apply (lt_irrefl M).
@@ -3335,13 +3335,13 @@ simpl.
 elim (le_lt_dec M (M + proj1_sig k)).
 move=> H15.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15)) = k).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15)) = k).
 move=> H16.
 rewrite H16.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15))) (proj1_sig k) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15))) (proj1_sig k) M).
+apply (proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig k) (H5 k)) H15)).
 move=> H15.
 apply False_ind.
 apply (lt_irrefl M).
@@ -3355,7 +3355,7 @@ move=> k.
 apply sig_map.
 apply (plus_reg_l (proj1_sig (proj1_sig (snd (snd u1)) k)) (proj1_sig (proj1_sig (snd (snd u2)) k)) M).
 suff: ((M + proj1_sig (proj1_sig (snd (snd u1)) k)) = let temp := (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b)))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
     | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
@@ -3552,7 +3552,7 @@ apply (H14 l k).
 apply le_S_n.
 apply H19.
 suff: (Im {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun k : {n : nat | (n < N)} => proj1_sig (fst u1 k)) = Im {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b)))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
     | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
@@ -3569,7 +3569,7 @@ move=> x H17 y H18.
 rewrite H18.
 unfold Basics.compose.
 unfold In.
-apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u2 k)) (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N x H17)))).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u2 k)) (proj1_sig (fst (snd u2)) (proj1_sig (H37 M N x H17)))).
 apply (Full_intro {n : nat | (n < N)}).
 elim (le_lt_dec M (proj1_sig x)).
 move=> H19.
@@ -3588,7 +3588,7 @@ rewrite H18.
 elim (proj2_sig (fst (snd u2))).
 move=> invg H19.
 apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N k b)))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (H37 M N k b))))) (H4 (fst u2 (proj1_sig (fst (snd u2)) (proj1_sig (H37 M N k b)))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u2 l) with
     | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => s < M) (proj1_sig k) b) H12 c)))) (H5 (proj1_sig (snd (snd u2)) (proj1_sig (H3 (fst u2) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H12 c))))
     | right _ => k
@@ -3599,17 +3599,17 @@ unfold Basics.compose.
 simpl.
 elim (le_lt_dec M (M + (proj1_sig (invg x)))).
 move=> H20.
-suff: ((proj1_sig (fst (snd u2)) (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20))) = x).
+suff: ((proj1_sig (fst (snd u2)) (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20))) = x).
 move=> H21.
 rewrite H21.
 reflexivity.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20)) = invg x).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20)) = invg x).
 move=> H21.
 rewrite H21.
 apply (proj2 H19 x).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20))) (proj1_sig (invg x)) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20))) (proj1_sig (invg x)) M).
+apply (proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H20)).
 move=> H20.
 apply False_ind.
 apply (lt_not_le (M + proj1_sig (invg x)) M H20).
@@ -3623,7 +3623,7 @@ rewrite H17.
 elim (proj2_sig (fst (snd u1))).
 move=> invg H18.
 apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (M <= proj1_sig k)) (Basics.compose (fun k : {n : nat | (n < M + N)} => proj1_sig k) (fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N k b)))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b))))) (H4 (fst u1 (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N k b)))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst u1 l) with
     | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => s < M) (proj1_sig k) b) H11 c)))) (H5 (proj1_sig (snd (snd u1)) (proj1_sig (H3 (fst u1) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H11 c))))
     | right _ => k
@@ -3634,17 +3634,17 @@ unfold Basics.compose.
 simpl.
 elim (le_lt_dec M (M + (proj1_sig (invg x)))).
 move=> H19.
-suff: ((proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19))) = x).
+suff: ((proj1_sig (fst (snd u1)) (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19))) = x).
 move=> H20.
 rewrite H20.
 reflexivity.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19)) = invg x).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19)) = invg x).
 move=> H20.
 rewrite H20.
 apply (proj2 H18 x).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19))) (proj1_sig (invg x)) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19))) (proj1_sig (invg x)) M).
+apply (proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (invg x)) (H5 (invg x))) H19)).
 move=> H19.
 apply False_ind.
 apply (lt_not_le (M + proj1_sig (invg x)) M H19).
@@ -3655,7 +3655,7 @@ move=> x H16 y H17.
 rewrite H17.
 unfold Basics.compose.
 unfold In.
-apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u1 k)) (proj1_sig (fst (snd u1)) (proj1_sig (blockdividesub M N x H16)))).
+apply (Im_intro {n : nat | (n < N)} nat (Full_set {n : nat | (n < N)}) (fun (k : {n : nat | (n < N)}) => proj1_sig (fst u1 k)) (proj1_sig (fst (snd u1)) (proj1_sig (H37 M N x H16)))).
 apply (Full_intro {n : nat | (n < N)}).
 elim (le_lt_dec M (proj1_sig x)).
 move=> H18.
@@ -3741,7 +3741,7 @@ elim.
 move=> p2 H14.
 apply (Im_intro (({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) (Permutation (M + N)) (proj1_sig (FinitePair ({n : nat | (n < N)} -> {n : nat | (n < M)}) (Permutation N * Permutation N) (FiniteIntersection ({n : nat | (n < N)} -> {n : nat | (n < M)}) (exist (Finite ({n : nat | (n < N)} -> {n : nat | (n < M)})) (Full_set ({n : nat | (n < N)} -> {n : nat | (n < M)})) (CountPowFinite N M)) (fun r : {n : nat | (n < N)} -> {n : nat | (n < M)} => forall p q : {n : nat | (n < N)}, (proj1_sig p < proj1_sig q) -> (proj1_sig (r p) < proj1_sig (r q)))) (FinitePair (Permutation N) (Permutation N) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))) (fun (x : ({n : nat | (n < N)} -> {n : nat | (n < M)}) * (Permutation N * Permutation N)) => exist Bijective match excluded_middle_informative (Injective (fst x)) with
   | left a => fun k : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig k) with
-    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k b)))))
+    | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b))))) (H4 (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k b)))))
     | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst x l) with
       | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) a c)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) b) a c))))
       | right _ => k
@@ -3768,13 +3768,13 @@ elim (le_lt_dec M (proj1_sig k)).
 move=> H16.
 apply sig_map.
 simpl.
-rewrite (H12 (proj1_sig (blockdividesub M N k H16))).
-suff: ((exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (blockdividesub M N k H16))) (H5 (proj1_sig (blockdividesub M N k H16)))) = k).
+rewrite (H12 (proj1_sig (H37 M N k H16))).
+suff: ((exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (H37 M N k H16))) (H5 (proj1_sig (H37 M N k H16)))) = k).
 move=> H17.
 rewrite H17.
 reflexivity.
 apply sig_map.
-apply (proj2_sig (blockdividesub M N k H16)).
+apply (proj2_sig (H37 M N k H16)).
 move=> H16.
 elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig k) H16 = g l)).
 move=> H17.
@@ -3972,17 +3972,17 @@ apply (CountCardinalBijective {x : {n : nat | (n < M + N)} | (M <= proj1_sig x)}
 suff: (forall (l : {n : nat | (n < N)}), (M <= M + proj1_sig l)).
 move=> H19.
 exists (fun (l : {n : nat | (n < N)}) => exist (fun (x : {n : nat | (n < M + N)}) => (M <= proj1_sig x)) (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig l) (H5 l)) (H19 l)).
-exists (fun (l : {x : {n : nat | (n < M + N)} | (M <= proj1_sig x)}) => proj1_sig (blockdividesub M N (proj1_sig l) (proj2_sig l))).
+exists (fun (l : {x : {n : nat | (n < M + N)} | (M <= proj1_sig x)}) => proj1_sig (H37 M N (proj1_sig l) (proj2_sig l))).
 apply conj.
 move=> t.
 apply sig_map.
 simpl.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig t) (H5 t)) (H19 t)))) (proj1_sig t) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig t) (H5 t)) (H19 t))).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig t) (H5 t)) (H19 t)))) (proj1_sig t) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig t) (H5 t)) (H19 t))).
 move=> t.
 apply sig_map.
 apply sig_map.
-apply (proj2_sig (blockdividesub M N (proj1_sig t) (proj2_sig t))).
+apply (proj2_sig (H37 M N (proj1_sig t) (proj2_sig t))).
 move=> l.
 apply le_plus_l.
 apply.
@@ -4004,12 +4004,12 @@ apply False_ind.
 apply (lt_irrefl (proj1_sig (g k1))).
 rewrite {1} H16.
 apply (proj2 H11 k2 k1 H17).
-suff: (Bijective (fun (m : {n : nat | (n < N)}) => (proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))) (H13 m))))).
+suff: (Bijective (fun (m : {n : nat | (n < N)}) => (proj1_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))) (H13 m))))).
 move=> H14.
-exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))) (H13 m))) H14).
+exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))) (H13 m))) H14).
 move=> m.
 simpl.
-apply (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m)))) (H13 m))).
+apply (proj2_sig (H37 M N (proj1_sig u0 (exist (fun (n : nat) => n < M + N) (proj1_sig (g m)) (H4 (g m)))) (H13 m))).
 apply CountInjBij.
 move=> k1 k2 H14.
 suff: ((proj1_sig (g k1)) = (proj1_sig (g k2))).
@@ -4038,9 +4038,9 @@ reflexivity.
 reflexivity.
 apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
-rewrite - (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g k1)) (H4 (g k1)))) (H13 k1))).
+rewrite - (proj2_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g k1)) (H4 (g k1)))) (H13 k1))).
 rewrite H14.
-apply (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g k2)) (H4 (g k2)))) (H13 k2))).
+apply (proj2_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (proj1_sig (g k2)) (H4 (g k2)))) (H13 k2))).
 move=> m.
 elim (le_or_lt M (proj1_sig (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (proj1_sig (g m)) (H4 (g m)))))).
 apply.
@@ -4471,14 +4471,14 @@ apply sig_map.
 apply H12.
 elim (proj2_sig k).
 move=> x H12 y H13.
-exists (proj1_sig (blockdividesub M N x H12)).
+exists (proj1_sig (H37 M N x H12)).
 rewrite H13.
-suff: ((exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (blockdividesub M N x H12))) (H5 (proj1_sig (blockdividesub M N x H12)))) = x).
+suff: ((exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (H37 M N x H12))) (H5 (proj1_sig (H37 M N x H12)))) = x).
 move=> H14.
 rewrite H14.
 reflexivity.
 apply sig_map.
-apply (proj2_sig (blockdividesub M N x H12)).
+apply (proj2_sig (H37 M N x H12)).
 move=> m.
 apply (Im_intro {n : nat | (n < M + N)} nat (fun (k : {n : nat | (n < M + N)}) => (proj1_sig k >= M)) (Basics.compose (fun (k : {n : nat | (n < M + N)}) => proj1_sig k) (proj1_sig u0)) (exist (fun s : nat => (s < M + N)) (M + proj1_sig m) (H5 m))).
 apply le_plus_l.
@@ -4512,7 +4512,7 @@ move=> fsti H7.
 elim (proj2_sig (snd (snd x))).
 move=> sndi H8.
 exists ((fun (k : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig k) with
-  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N k b))))) (H4 (fst x (sndi (proj1_sig (blockdividesub M N k b)))))
+  | left b => exist (fun s : nat => (s < M + N)) (proj1_sig (fst x (sndi (proj1_sig (H37 M N k b))))) (H4 (fst x (sndi (proj1_sig (H37 M N k b)))))
   | right b => match excluded_middle_informative (exists l : {n : nat | (n < N)}, exist (fun s : nat => (s < M)) (proj1_sig k) b = fst x l) with
     | left c => exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) b) H6 c)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) b) H6 c))))
     | right _ => k
@@ -4523,30 +4523,30 @@ move=> k.
 elim (le_lt_dec M (proj1_sig k)).
 move=> H9.
 simpl.
-elim (le_lt_dec M (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9)))))).
+elim (le_lt_dec M (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9)))))).
 move=> H10.
 apply sig_map.
 simpl.
 apply False_ind.
-apply (le_not_lt M (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10 (proj2_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9)))))).
+apply (le_not_lt M (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9))))) H10 (proj2_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9)))))).
 move=> H10.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9))))) H10 = fst x l)).
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10) H6 H11)) = (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9)))).
+suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9))))) H10) H6 H11)) = (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9)))).
 move=> H12.
 rewrite H12.
 rewrite (proj1 H7).
-apply (proj2_sig (blockdividesub M N k H9)).
+apply (proj2_sig (H37 M N k H9)).
 apply H6.
-rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))))) H10) H6 H11)).
+rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9))))) H10) H6 H11)).
 apply sig_map.
 reflexivity.
 move=> H11.
 apply False_ind.
 apply H11.
-exists (proj1_sig (fst (snd x)) (proj1_sig (blockdividesub M N k H9))).
+exists (proj1_sig (fst (snd x)) (proj1_sig (H37 M N k H9))).
 apply sig_map.
 reflexivity.
 move=> H9.
@@ -4557,15 +4557,15 @@ elim (le_lt_dec M (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x)
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11)) = (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11)) = (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))).
 move=> H12.
 rewrite H12.
 rewrite (proj1 H8).
 rewrite - (proj2_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig k) H9) H6 H10)).
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11))) (proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11))) (proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10)))) M).
+apply (proj2_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10)))) (H5 (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig k) H9) H6 H10))))) H11)).
 move=> H11.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig (proj1_sig (snd (snd x)) (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig k) H9) H6 H10))))).
@@ -4595,28 +4595,28 @@ move=> y.
 elim (le_lt_dec M (proj1_sig y)).
 move=> H9.
 simpl.
-elim (le_lt_dec M (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9)))))).
+elim (le_lt_dec M (proj1_sig (fst x (sndi (proj1_sig (H37 M N y H9)))))).
 move=> H10.
 apply False_ind.
-apply (le_not_lt M (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10 (proj2_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9)))))).
+apply (le_not_lt M (proj1_sig (fst x (sndi (proj1_sig (H37 M N y H9))))) H10 (proj2_sig (fst x (sndi (proj1_sig (H37 M N y H9)))))).
 move=> H10.
-elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10 = fst x l)).
+elim (excluded_middle_informative (exists (l : {n : nat | (n < N)}), exist (fun s : nat => (s < M)) (proj1_sig (fst x (sndi (proj1_sig (H37 M N y H9))))) H10 = fst x l)).
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10) H6 H11)) = (sndi (proj1_sig (blockdividesub M N y H9)))).
+suff: ((proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig (fst x (sndi (proj1_sig (H37 M N y H9))))) H10) H6 H11)) = (sndi (proj1_sig (H37 M N y H9)))).
 move=> H12.
 rewrite H12.
 rewrite (proj2 H8).
-apply (proj2_sig (blockdividesub M N y H9)).
+apply (proj2_sig (H37 M N y H9)).
 apply H6.
-rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig (fst x (sndi (proj1_sig (blockdividesub M N y H9))))) H10) H6 H11)).
+rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig (fst x (sndi (proj1_sig (H37 M N y H9))))) H10) H6 H11)).
 apply sig_map.
 reflexivity.
 move=> H11.
 apply False_ind.
 apply H11.
-exists (sndi (proj1_sig (blockdividesub M N y H9))).
+exists (sndi (proj1_sig (H37 M N y H9))).
 apply sig_map.
 reflexivity.
 move=> H9.
@@ -4627,15 +4627,15 @@ elim (le_lt_dec M (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : na
 move=> H11.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))) H11)) = (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))).
+suff: ((proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))) H11)) = (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))).
 move=> H12.
 rewrite H12.
 rewrite (proj2 H7).
 rewrite - (proj2_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10)).
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))) H11))) (proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig y) H9) H6 H10))))) H11)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun s : nat => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10))))) H11))) (proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => (s < M)) (proj1_sig y) H9) H6 H10)))) M).
+apply (proj2_sig (H37 M N (exist (fun (s : nat) => (s < M + N)) (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => s < M) (proj1_sig y) H9) H6 H10)))) (H5 (fsti (proj1_sig (H3 (fst x) (exist (fun (s : nat) => (s < M)) (proj1_sig y) H9) H6 H10))))) H11)).
 move=> H11.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig (fsti (proj1_sig (H3 (fst x) (exist (fun s : nat => s < M) (proj1_sig y) H9) H6 H10))))).
@@ -4852,16 +4852,16 @@ unfold Determinant.
 suff: (forall (m : {n : nat | (n < N)}), (M + proj1_sig m < M + N)).
 move=> H5.
 suff: (forall (P : Permutation N), Bijective (fun (m : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H))))
   | right _ => m
 end)).
 move=> H6.
 rewrite (MySumF2Included (Permutation (M + N)) (FiniteIm (Permutation N) (Permutation (M + N)) (fun (P : (Permutation N)) => exist Bijective (fun (m : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun (n : nat) => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H))))
   | right _ => m
 end) (H6 P)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N)))).
 rewrite (MySumF2O (Permutation (M + N)) (FiniteIntersection (Permutation (M + N)) (exist (Finite (Permutation (M + N))) (Full_set (Permutation (M + N))) (PermutationFinite (M + N))) (Complement (Permutation (M + N)) (proj1_sig (FiniteIm (Permutation N) (Permutation (M + N)) (fun P : Permutation N => exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H))))
   | right _ => m
 end) (H6 P)) (exist (Finite (Permutation N)) (Full_set (Permutation N)) (PermutationFinite N))))))).
 rewrite (CM_O_r (FPCM f)).
@@ -4870,7 +4870,7 @@ unfold Basics.compose.
 apply MySumF2Same.
 move=> P H7.
 suff: (PermutationParity N P = PermutationParity (M + N) (exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H))))
   | right _ => m
 end) (H6 P))).
 move=> H8.
@@ -4890,26 +4890,26 @@ simpl.
 elim (le_lt_dec M (M + proj1_sig x)).
 move=> H10.
 simpl.
-elim (le_lt_dec M (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) (@proj1_sig (forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N)) (fun f0 : forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N) => @Bijective (@sig nat (fun n : nat => lt n N)) (@sig nat (fun n : nat => lt n N)) f0) P (@proj1_sig (@sig nat (fun n : nat => lt n N)) (fun y : @sig nat (fun n : nat => lt n N) => @eq nat (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) y)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) x))) (blockdividesub M N (@exist nat (fun n : nat => lt n (Init.Nat.add M N)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) x)) (H5 x)) H10)))))).
+elim (le_lt_dec M (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) (@proj1_sig (forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N)) (fun f0 : forall _ : @sig nat (fun n : nat => lt n N), @sig nat (fun n : nat => lt n N) => @Bijective (@sig nat (fun n : nat => lt n N)) (@sig nat (fun n : nat => lt n N)) f0) P (@proj1_sig (@sig nat (fun n : nat => lt n N)) (fun y : @sig nat (fun n : nat => lt n N) => @eq nat (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) y)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) x))) (H37 M N (@exist nat (fun n : nat => lt n (Init.Nat.add M N)) (Init.Nat.add M (@proj1_sig nat (fun n : nat => lt n N) x)) (H5 x)) H10)))))).
 move=> H11.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10)) = x).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10)) = x).
 move=> H12.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))))) H11)) = proj1_sig P x).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))))) H11)) = proj1_sig P x).
 move=> H13.
 rewrite H13.
 rewrite H12.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))))) H11))) (proj1_sig (proj1_sig P x)) M).
-rewrite (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))) H11)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))))) H11))) (proj1_sig (proj1_sig P x)) M).
+rewrite (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)))) (H5 (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))) H11)).
 rewrite H12.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))) (proj1_sig x) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig x) (H5 x)) H10))) (proj1_sig x) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10)).
 move=> H11.
 apply False_ind.
-apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))).
+apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig x) (H5 x)) H10))))).
 apply le_plus_l.
 apply H11.
 move=> H10.
@@ -4933,11 +4933,11 @@ elim H9.
 move=> u0 H10 H11 H12.
 apply False_ind.
 apply H10.
-apply (Im_intro {n : nat | (n < N)} {n : nat | (n < M + N)} (Full_set {n : nat | (n < N)}) (fun (m : {n : nat | (n < N)}) => exist (fun n : nat => (n < M + N)) (M + proj1_sig m) (H5 m)) (proj1_sig (blockdividesub M N u0 H12))).
+apply (Im_intro {n : nat | (n < N)} {n : nat | (n < M + N)} (Full_set {n : nat | (n < N)}) (fun (m : {n : nat | (n < N)}) => exist (fun n : nat => (n < M + N)) (M + proj1_sig m) (H5 m)) (proj1_sig (H37 M N u0 H12))).
 apply (Full_intro {n : nat | (n < N)}).
 apply sig_map.
 simpl.
-rewrite (proj2_sig (blockdividesub M N u0 H12)).
+rewrite (proj2_sig (H37 M N u0 H12)).
 reflexivity.
 move=> H10.
 elim (le_lt_dec M (proj1_sig u)).
@@ -4974,10 +4974,10 @@ move=> H9.
 elim (le_lt_dec M (M + proj1_sig (snd xy))).
 move=> H10.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)) = fst xy).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)) = fst xy).
 move=> H11.
 rewrite H11.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)) = snd xy).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)) = snd xy).
 move=> H12.
 rewrite H12.
 elim (excluded_middle_informative (proj1_sig (proj1_sig P (fst xy)) < proj1_sig (proj1_sig P (snd xy)))).
@@ -4999,11 +4999,11 @@ apply (plus_lt_reg_l (proj1_sig (proj1_sig P (fst xy))) (proj1_sig (proj1_sig P 
 move=> H14.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10))) (proj1_sig (snd xy)) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10))) (proj1_sig (snd xy)) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (snd xy)) (H5 (snd xy))) H10)).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9))) (proj1_sig (fst xy)) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9))) (proj1_sig (fst xy)) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (fst xy)) (H5 (fst xy))) H9)).
 move=> H10.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig (snd xy)) (le_plus_l M (proj1_sig (snd xy))) H10).
@@ -5035,19 +5035,19 @@ elim H8.
 move=> u0 H9 H10 H11 H12.
 apply False_ind.
 apply H9.
-apply (Im_intro ({n : nat | (n < N)} * {n : nat | (n < N)}) ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (fun (xy : {n : nat | (n < N)} * {n : nat | (n < N)}) => (proj1_sig (fst xy) < proj1_sig (snd xy))) (fun m : {n : nat | (n < N)} * {n : nat | (n < N)} => (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst m)) (H5 (fst m)), exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd m)) (H5 (snd m)))) (proj1_sig (blockdividesub M N (fst u0) H12), proj1_sig (blockdividesub M N (snd u0) H11))).
-apply (plus_lt_reg_l (proj1_sig (proj1_sig (blockdividesub M N (fst u0) H12))) (proj1_sig (proj1_sig (blockdividesub M N (snd u0) H11))) M).
-rewrite (proj2_sig (blockdividesub M N (fst u0) H12)).
-rewrite (proj2_sig (blockdividesub M N (snd u0) H11)).
+apply (Im_intro ({n : nat | (n < N)} * {n : nat | (n < N)}) ({n : nat | (n < M + N)} * {n : nat | (n < M + N)}) (fun (xy : {n : nat | (n < N)} * {n : nat | (n < N)}) => (proj1_sig (fst xy) < proj1_sig (snd xy))) (fun m : {n : nat | (n < N)} * {n : nat | (n < N)} => (exist (fun n : nat => (n < M + N)) (M + proj1_sig (fst m)) (H5 (fst m)), exist (fun n : nat => (n < M + N)) (M + proj1_sig (snd m)) (H5 (snd m)))) (proj1_sig (H37 M N (fst u0) H12), proj1_sig (H37 M N (snd u0) H11))).
+apply (plus_lt_reg_l (proj1_sig (proj1_sig (H37 M N (fst u0) H12))) (proj1_sig (proj1_sig (H37 M N (snd u0) H11))) M).
+rewrite (proj2_sig (H37 M N (fst u0) H12)).
+rewrite (proj2_sig (H37 M N (snd u0) H11)).
 apply H10.
 apply injective_projections.
 apply sig_map.
 simpl.
-rewrite (proj2_sig (blockdividesub M N (fst u0) H12)).
+rewrite (proj2_sig (H37 M N (fst u0) H12)).
 reflexivity.
 apply sig_map.
 simpl.
-rewrite (proj2_sig (blockdividesub M N (snd u0) H11)).
+rewrite (proj2_sig (H37 M N (snd u0) H11)).
 reflexivity.
 elim H8.
 move=> u0 H9 H10 H11 H12.
@@ -5056,13 +5056,13 @@ apply (le_not_lt M (proj1_sig (fst u0)) H12 (lt_trans (proj1_sig (fst u0)) (proj
 elim (le_lt_dec M (proj1_sig (snd u))).
 move=> H9 H10.
 simpl.
-elim (excluded_middle_informative (proj1_sig (fst u) < M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (snd u) H9))))).
+elim (excluded_middle_informative (proj1_sig (fst u) < M + proj1_sig (proj1_sig P (proj1_sig (H37 M N (snd u) H9))))).
 move=> H11.
 reflexivity.
 move=> H11.
 apply False_ind.
 apply H11.
-apply (le_trans (S (proj1_sig (fst u))) M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N (snd u) H9))))).
+apply (le_trans (S (proj1_sig (fst u))) M (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N (snd u) H9))))).
 apply H10.
 apply le_plus_l.
 move=> H9 H10.
@@ -5086,7 +5086,7 @@ apply functional_extensionality.
 move=> m.
 apply sig_map.
 suff: (proj1_sig (proj1_sig u1 m) = proj1_sig (proj1_sig (exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig u1 (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig u1 (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig u1 (proj1_sig (H37 M N m H)))) (H5 (proj1_sig u1 (proj1_sig (H37 M N m H))))
   | right _ => m
 end) (H6 u1)) (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) - M).
 move=> H10.
@@ -5095,13 +5095,13 @@ rewrite H9.
 simpl.
 elim (le_lt_dec M (M + proj1_sig m)).
 move=> H11.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)) = m).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)) = m).
 move=> H12.
 rewrite H12.
 apply minus_plus.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) H11))) (proj1_sig m) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) H11))) (proj1_sig m) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H11)).
 move=> H11.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig m)).
@@ -5110,15 +5110,15 @@ apply H11.
 simpl.
 elim (le_lt_dec M (M + proj1_sig m)).
 move=> H10.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)) = m).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)) = m).
 move=> H11.
 rewrite H11.
 simpl.
 rewrite minus_plus.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) H10))) (proj1_sig m) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) H10))) (proj1_sig m) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) H10)).
 move=> H10.
 apply False_ind.
 apply (le_not_lt M (M + proj1_sig m)).
@@ -5149,7 +5149,7 @@ suff: (exists (P : Permutation N), forall (m : {n : nat | (n < N)}), proj1_sig (
 elim.
 move=> P H12.
 apply (Im_intro (Permutation N) (Permutation (M + N)) (Full_set (Permutation N)) (fun (P : Permutation N) => exist Bijective (fun m : {n : nat | (n < M + N)} => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H))))
   | right _ => m
 end) (H6 P)) P).
 apply (Full_intro (Permutation N) P).
@@ -5160,24 +5160,24 @@ simpl.
 elim (le_lt_dec M (proj1_sig m)).
 move=> H13.
 apply sig_map.
-suff: (m = (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (blockdividesub M N m H13))) (H5 (proj1_sig (blockdividesub M N m H13))))).
+suff: (m = (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig (H37 M N m H13))) (H5 (proj1_sig (H37 M N m H13))))).
 move=> H14.
 rewrite {1} H14.
-apply (H12 (proj1_sig (blockdividesub M N m H13))).
+apply (H12 (proj1_sig (H37 M N m H13))).
 apply sig_map.
 simpl.
-rewrite (proj2_sig (blockdividesub M N m H13)).
+rewrite (proj2_sig (H37 M N m H13)).
 reflexivity.
 move=> H13.
 apply (H20 m H13).
 suff: (forall (m : {n : nat | (n < N)}), M <= M + proj1_sig m).
 move=> H12.
-suff: (Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (H12 m))))).
+suff: (Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (H37 M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (H12 m))))).
 move=> H13.
-exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (blockdividesub M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (H12 m)))) H13).
+exists (exist Bijective (fun (m : {n : nat | (n < N)}) => proj1_sig (H37 M N (proj1_sig u0 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m))) (H11 (exist (fun (n : nat) => (n < M + N)) (M + proj1_sig m) (H5 m)) (H12 m)))) H13).
 simpl.
 move=> m.
-rewrite (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m))) (H11 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) (H12 m)))).
+rewrite (proj2_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m))) (H11 (exist (fun n : nat => n < M + N) (M + proj1_sig m) (H5 m)) (H12 m)))).
 reflexivity.
 apply CountInjBij.
 move=> m1 m2 H13.
@@ -5193,9 +5193,9 @@ reflexivity.
 reflexivity.
 apply (BijInj {n : nat | (n < M + N)} {n : nat | (n < M + N)} (proj1_sig u0) (proj2_sig u0)).
 apply sig_map.
-rewrite - (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m1) (H5 m1))) (H11 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m1) (H5 m1)) (H12 m1)))).
+rewrite - (proj2_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m1) (H5 m1))) (H11 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m1) (H5 m1)) (H12 m1)))).
 rewrite H13.
-rewrite (proj2_sig (blockdividesub M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m2) (H5 m2))) (H11 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m2) (H5 m2)) (H12 m2)))).
+rewrite (proj2_sig (H37 M N (proj1_sig u0 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m2) (H5 m2))) (H11 (exist (fun n : nat => (n < M + N)) (M + proj1_sig m2) (H5 m2)) (H12 m2)))).
 reflexivity.
 move=> m.
 apply le_plus_l.
@@ -5245,7 +5245,7 @@ move=> P.
 elim (proj2_sig P).
 move=> Pinv H6.
 exists (fun (m : {n : nat | (n < M + N)}) => match le_lt_dec M (proj1_sig m) with
-  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H))))
+  | left H => exist (fun n : nat => (n < M + N)) (M + proj1_sig (Pinv (proj1_sig (H37 M N m H)))) (H5 (Pinv (proj1_sig (H37 M N m H))))
   | right _ => m
 end).
 apply conj.
@@ -5253,21 +5253,21 @@ move=> m.
 elim (le_lt_dec M (proj1_sig m)).
 move=> H7.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7))))).
+elim (le_lt_dec M (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H7))))).
 move=> H8.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8)) = (proj1_sig P (proj1_sig (blockdividesub M N m H7)))).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H7)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H7))))) H8)) = (proj1_sig P (proj1_sig (H37 M N m H7)))).
 move=> H9.
 rewrite H9.
 rewrite (proj1 H6).
-apply (proj2_sig (blockdividesub M N m H7)).
+apply (proj2_sig (H37 M N m H7)).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8))) (proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7)))) (H5 (proj1_sig P (proj1_sig (blockdividesub M N m H7))))) H8)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H7)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H7))))) H8))) (proj1_sig (proj1_sig P (proj1_sig (H37 M N m H7)))) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H7)))) (H5 (proj1_sig P (proj1_sig (H37 M N m H7))))) H8)).
 move=> H8.
 apply False_ind.
-apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (blockdividesub M N m H7))))).
+apply (le_not_lt M (M + proj1_sig (proj1_sig P (proj1_sig (H37 M N m H7))))).
 apply le_plus_l.
 apply H8.
 move=> H7.
@@ -5281,21 +5281,21 @@ move=> m.
 elim (le_lt_dec M (proj1_sig m)).
 move=> H7.
 simpl.
-elim (le_lt_dec M (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7))))).
+elim (le_lt_dec M (M + proj1_sig (Pinv (proj1_sig (H37 M N m H7))))).
 move=> H8.
 apply sig_map.
 simpl.
-suff: ((proj1_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8)) = (Pinv (proj1_sig (blockdividesub M N m H7)))).
+suff: ((proj1_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (H37 M N m H7)))) (H5 (Pinv (proj1_sig (H37 M N m H7))))) H8)) = (Pinv (proj1_sig (H37 M N m H7)))).
 move=> H9.
 rewrite H9.
 rewrite (proj2 H6).
-apply (proj2_sig (blockdividesub M N m H7)).
+apply (proj2_sig (H37 M N m H7)).
 apply sig_map.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8))) (proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) M).
-apply (proj2_sig (blockdividesub M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7)))) (H5 (Pinv (proj1_sig (blockdividesub M N m H7))))) H8)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N (exist (fun n : nat => (n < M + N)) (M + proj1_sig (Pinv (proj1_sig (H37 M N m H7)))) (H5 (Pinv (proj1_sig (H37 M N m H7))))) H8))) (proj1_sig (Pinv (proj1_sig (H37 M N m H7)))) M).
+apply (proj2_sig (H37 M N (exist (fun n : nat => n < M + N) (M + proj1_sig (Pinv (proj1_sig (H37 M N m H7)))) (H5 (Pinv (proj1_sig (H37 M N m H7))))) H8)).
 move=> H8.
 apply False_ind.
-apply (le_not_lt M (M + proj1_sig (Pinv (proj1_sig (blockdividesub M N m H7))))).
+apply (le_not_lt M (M + proj1_sig (Pinv (proj1_sig (H37 M N m H7))))).
 apply le_plus_l.
 apply H8.
 move=> H7.
@@ -5389,24 +5389,24 @@ move=> H3.
 unfold MI.
 elim (Nat.eq_dec (proj1_sig x) (proj1_sig y)).
 move=> H4.
-elim (Nat.eq_dec (proj1_sig (proj1_sig (blockdividesub M N x H2))) (proj1_sig (proj1_sig (blockdividesub M N y H3)))).
+elim (Nat.eq_dec (proj1_sig (proj1_sig (H37 M N x H2))) (proj1_sig (proj1_sig (H37 M N y H3)))).
 move=> H5.
 reflexivity.
 move=> H5.
 apply False_ind.
 apply H5.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N x H2))) (proj1_sig (proj1_sig (blockdividesub M N y H3))) M).
-rewrite (proj2_sig (blockdividesub M N x H2)).
-rewrite (proj2_sig (blockdividesub M N y H3)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N x H2))) (proj1_sig (proj1_sig (H37 M N y H3))) M).
+rewrite (proj2_sig (H37 M N x H2)).
+rewrite (proj2_sig (H37 M N y H3)).
 apply H4.
 move=> H4.
-elim (Nat.eq_dec (proj1_sig (proj1_sig (blockdividesub M N x H2))) (proj1_sig (proj1_sig (blockdividesub M N y H3)))).
+elim (Nat.eq_dec (proj1_sig (proj1_sig (H37 M N x H2))) (proj1_sig (proj1_sig (H37 M N y H3)))).
 move=> H5.
 apply False_ind.
 apply H4.
-rewrite - (proj2_sig (blockdividesub M N x H2)).
+rewrite - (proj2_sig (H37 M N x H2)).
 rewrite H5.
-apply (proj2_sig (blockdividesub M N y H3)).
+apply (proj2_sig (H37 M N y H3)).
 move=> H5.
 reflexivity.
 move=> H3.
@@ -5422,7 +5422,7 @@ reflexivity.
 move=> H2.
 elim (le_lt_dec M (proj1_sig y)).
 move=> H3.
-suff: (~ In ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => C (fst xy) (snd xy) <> FO f) ((exist (fun n : nat => (n < M)) (proj1_sig x) H2), (proj1_sig (blockdividesub M N y H3)))).
+suff: (~ In ({n : nat | (n < M)} * {n : nat | (n < N)}) (fun (xy : {n : nat | (n < M)} * {n : nat | (n < N)}) => C (fst xy) (snd xy) <> FO f) ((exist (fun n : nat => (n < M)) (proj1_sig x) H2), (proj1_sig (H37 M N y H3)))).
 move=> H4.
 apply NNPP.
 move=> H5.
@@ -5648,7 +5648,7 @@ move=> H8.
 apply False_ind.
 apply (le_not_lt M (proj1_sig (fst d)) H8 (proj2_sig (fst d))).
 move=> H8.
-elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)) (proj1_sig x) H6, proj1_sig (blockdividesub M N y H7)) = d)).
+elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)) (proj1_sig x) H6, proj1_sig (H37 M N y H7)) = d)).
 move=> H9.
 rewrite (Fadd_O_l f).
 unfold MI.
@@ -5675,8 +5675,8 @@ simpl.
 apply H10.
 apply sig_map.
 simpl.
-apply (plus_reg_l (proj1_sig (proj1_sig (blockdividesub M N y H7))) (proj1_sig (snd d)) M).
-rewrite (proj2_sig (blockdividesub M N y H7)).
+apply (plus_reg_l (proj1_sig (proj1_sig (H37 M N y H7))) (proj1_sig (snd d)) M).
+rewrite (proj2_sig (H37 M N y H7)).
 apply (proj2 H5).
 move=> H10.
 rewrite (Fmul_O_l f).
@@ -5699,7 +5699,7 @@ reflexivity.
 move=> H6.
 elim (le_lt_dec M (proj1_sig y)).
 move=> H7.
-elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)) (proj1_sig x) H6, proj1_sig (blockdividesub M N y H7)) = d)).
+elim (excluded_middle_informative ((exist (fun (n : nat) => (n < M)) (proj1_sig x) H6, proj1_sig (H37 M N y H7)) = d)).
 move=> H8.
 apply False_ind.
 apply H5.
@@ -5707,7 +5707,7 @@ apply conj.
 reflexivity.
 rewrite - H8.
 simpl.
-rewrite (proj2_sig (blockdividesub M N y H7)).
+rewrite (proj2_sig (H37 M N y H7)).
 reflexivity.
 move=> H8.
 reflexivity.
@@ -5759,13 +5759,13 @@ elim (AddConnectInv N1 N2 y).
 move=> m.
 elim.
 move=> m H2.
-suff: (m = (proj1_sig (blockdividesub N1 N2 y H1))).
+suff: (m = (proj1_sig (H37 N1 N2 y H1))).
 move=> H3.
 rewrite H3.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig m) (proj1_sig (proj1_sig (blockdividesub N1 N2 y H1))) N1).
-rewrite (proj2_sig (blockdividesub N1 N2 y H1)).
+apply (plus_reg_l (proj1_sig m) (proj1_sig (proj1_sig (H37 N1 N2 y H1))) N1).
+rewrite (proj2_sig (H37 N1 N2 y H1)).
 rewrite H2.
 reflexivity.
 apply (proj2 (AddConnectInvNature N1 N2) y H1).
@@ -5813,13 +5813,13 @@ elim (AddConnectInv M1 M2 x).
 move=> m.
 elim.
 move=> m H2.
-suff: (m = (proj1_sig (blockdividesub M1 M2 x H1))).
+suff: (m = (proj1_sig (H37 M1 M2 x H1))).
 move=> H3.
 rewrite H3.
 reflexivity.
 apply sig_map.
-apply (plus_reg_l (proj1_sig m) (proj1_sig (proj1_sig (blockdividesub M1 M2 x H1))) M1).
-rewrite (proj2_sig (blockdividesub M1 M2 x H1)).
+apply (plus_reg_l (proj1_sig m) (proj1_sig (proj1_sig (H37 M1 M2 x H1))) M1).
+rewrite (proj2_sig (H37 M1 M2 x H1)).
 rewrite H2.
 reflexivity.
 apply (proj2 (AddConnectInvNature M1 M2) x H1).


### PR DESCRIPTION
## 概要
`{n : nat | n < N} + {n : nat | n < M}`から` {n : nat | n < N + M}`への自然な全単射を1つ構成し様々な性質を示した。また、行列のブロック分けを変更しその全単射を用いた定義にした。